### PR TITLE
Adding Base support on algebra-integral

### DIFF
--- a/src/dex/algebra-integral/config.ts
+++ b/src/dex/algebra-integral/config.ts
@@ -12,5 +12,14 @@ export const AlgebraIntegralConfig: DexConfigMap<DexParams> = {
       uniswapMulticall: '0x536310b521120dd3c195e78e5c26d61b938a4594',
       chunksCount: 10,
     },
+    [Network.BASE]: {
+      factory: '0xC5396866754799B9720125B104AE01d935Ab9C7b',
+      subgraphURL:
+        'https://api.studio.thegraph.com/query/113693/quickswap-algebra-base/version/latest',
+      quoter: '0xA8a1dA1279ea63535c7B3BE8D20241483BC61009',
+      router: '0xe6c9bb24ddB4aE5c6632dbE0DE14e3E474c6Cb04',
+      uniswapMulticall: '0xD55AbC52a0d9901AD07FEbe2903d05601E2a34dD',
+      chunksCount: 10,
+    },
   },
 };


### PR DESCRIPTION
# QuickSwap V4 (Algebra Integral) Support for Base Network - PR Summary

Adds support for QuickSwap V4 (Algebra Integral protocol) on Base network (Chain ID: 8453) to enable liquidity aggregation through Paraswap.

## Context
- **Previous PR**: [#1027](https://github.com/VeloraDEX/paraswap-dex-lib/pull/1027) added QuickSwap V2 support for Base network (already merged)
- **This PR**: Adds QuickSwap V4 (Algebra Integral v2.1) support for Base network
- **Reference**: Based on PR [#914](https://github.com/VeloraDEX/paraswap-dex-lib/pull/914) (Algebra Integral integration) as requested by Paraswap team