### PR TITLE
feat: add OS ARM pool

### DIFF
--- a/src/dex/oswap/config.ts
+++ b/src/dex/oswap/config.ts
@@ -19,6 +19,16 @@ export const OSwapConfig: DexConfigMap<DexParams> = {
         },
       ],
     },
+    [Network.SONIC]: {
+      pools: [
+        {
+          id: 'OSwap_0x2f872623d1e1af5835b08b0e49aad2d81d649d30', // Pool identifier: `{dex_key}_{pool_address}`
+          address: '0x2f872623d1e1af5835b08b0e49aad2d81d649d30', // Address of the pool
+          token0: '0x039e2fb66102314ce7b64ce5ce3e5183bc94ad38', // WS
+          token1: '0xb1e25689d55734fd3fffc939c4c3eb52dff8a794', // OS
+        },
+      ],
+    },
   },
 };
 

--- a/src/dex/oswap/oswap-e2e.test.ts
+++ b/src/dex/oswap/oswap-e2e.test.ts
@@ -88,4 +88,23 @@ describe('Oswap E2E', () => {
       tokenBAmount,
     );
   });
+
+  describe('Sonic', () => {
+    const network = Network.SONIC;
+
+    const tokenASymbol: string = 'WS';
+    const tokenBSymbol: string = 'OS';
+
+    const tokenAAmount: string = '1000000000000000000';
+    const tokenBAmount: string = '1000000000000000000';
+
+    testForNetwork(
+      network,
+      dexKey,
+      tokenASymbol,
+      tokenBSymbol,
+      tokenAAmount,
+      tokenBAmount,
+    );
+  });
 });

--- a/src/dex/oswap/oswap-integration.test.ts
+++ b/src/dex/oswap/oswap-integration.test.ts
@@ -288,4 +288,152 @@ describe('OSwap', function () {
       }
     });
   });
+
+  describe('Sonic', () => {
+    const network = Network.SONIC;
+    const dexHelper = new DummyDexHelper(network);
+
+    const tokens = Tokens[network];
+
+    const srcTokenSymbol = 'WS';
+    const destTokenSymbol = 'OS';
+
+    const amountsForSell = [
+      0n,
+      1n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      2n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      3n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      4n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      5n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      6n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      7n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      8n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      9n * BI_POWS[tokens[srcTokenSymbol].decimals],
+      10n * BI_POWS[tokens[srcTokenSymbol].decimals],
+    ];
+
+    const amountsForBuy = [
+      0n,
+      1n * BI_POWS[tokens[destTokenSymbol].decimals],
+      2n * BI_POWS[tokens[destTokenSymbol].decimals],
+      3n * BI_POWS[tokens[destTokenSymbol].decimals],
+      4n * BI_POWS[tokens[destTokenSymbol].decimals],
+      5n * BI_POWS[tokens[destTokenSymbol].decimals],
+      6n * BI_POWS[tokens[destTokenSymbol].decimals],
+      7n * BI_POWS[tokens[destTokenSymbol].decimals],
+      8n * BI_POWS[tokens[destTokenSymbol].decimals],
+      9n * BI_POWS[tokens[destTokenSymbol].decimals],
+      10n * BI_POWS[tokens[destTokenSymbol].decimals],
+    ];
+
+    // Return a blockNumber to use for the tests.
+    // Check that the pool has enough liquidity to run the tests at the current blockNumber.
+    // If not, fallback to a known blockNumber in the past with
+    // high enough liquidity - the on-chain queries will just be a bit slower to execute.
+    async function getBlockNumberForTesting(oswap: OSwap): Promise<number> {
+      const DEFAULT_BLOCK_NUMBER = 41000000;
+
+      blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      const srcToken = Tokens[network][srcTokenSymbol];
+      const destToken = Tokens[network][destTokenSymbol];
+
+      // Get the pool and its state for the given test pair.
+      const pool = oswap.getPoolByTokenPair(srcToken, destToken);
+      if (!pool)
+        throw new Error(
+          `No pool found for pair ${srcTokenSymbol}-${destTokenSymbol}`,
+        );
+
+      const eventPool = oswap.eventPools[pool.id];
+      const state = await eventPool.getStateOrGenerate(blockNumber, true);
+
+      const minBalance =
+        state.balance0 < state.balance1 ? state.balance0 : state.balance1;
+      const maxAmount = [...amountsForSell, ...amountsForBuy].reduce(
+        (max, amount) => (amount > max ? amount : max),
+      );
+      const hasEnoughLiquidity = BigInt(minBalance) > maxAmount;
+
+      if (!hasEnoughLiquidity) {
+        return DEFAULT_BLOCK_NUMBER;
+      }
+      return blockNumber;
+    }
+
+    beforeAll(async () => {
+      oswap = new OSwap(network, dexKey, dexHelper);
+
+      blockNumber = await getBlockNumberForTesting(oswap);
+    });
+
+    it('getPoolIdentifiers and getPricesVolume SELL', async function () {
+      await testPricingOnNetwork(
+        oswap,
+        network,
+        dexKey,
+        blockNumber,
+        srcTokenSymbol,
+        destTokenSymbol,
+        SwapSide.SELL,
+        amountsForSell,
+      );
+    });
+
+    it('getPoolIdentifiers and getPricesVolume BUY', async function () {
+      await testPricingOnNetwork(
+        oswap,
+        network,
+        dexKey,
+        blockNumber,
+        srcTokenSymbol,
+        destTokenSymbol,
+        SwapSide.BUY,
+        amountsForBuy,
+      );
+    });
+
+    it(`getTopPoolsForToken ${srcTokenSymbol}`, async function () {
+      // We have to check without calling initializePricing, because
+      // pool-tracker is not calling that function
+      const newOSwap = new OSwap(network, dexKey, dexHelper);
+      await newOSwap.updatePoolState?.();
+
+      const poolLiquidity = await newOSwap.getTopPoolsForToken(
+        tokens[srcTokenSymbol].address,
+        10,
+      );
+
+      console.log(`${srcTokenSymbol} top pools:`, poolLiquidity);
+
+      if (!newOSwap.hasConstantPriceLargeAmounts) {
+        checkPoolsLiquidity(
+          poolLiquidity,
+          Tokens[network][srcTokenSymbol].address,
+          dexKey,
+        );
+      }
+    });
+
+    it(`getTopPoolsForToken ${destTokenSymbol}`, async function () {
+      // We have to check without calling initializePricing, because
+      // pool-tracker is not calling that function
+      const newOSwap = new OSwap(network, dexKey, dexHelper);
+      await newOSwap.updatePoolState?.();
+
+      const poolLiquidity = await newOSwap.getTopPoolsForToken(
+        tokens[destTokenSymbol].address,
+        10,
+      );
+
+      console.log(`${destTokenSymbol} top pools:`, poolLiquidity);
+
+      if (!newOSwap.hasConstantPriceLargeAmounts) {
+        checkPoolsLiquidity(
+          poolLiquidity,
+          Tokens[network][destTokenSymbol].address,
+          dexKey,
+        );
+      }
+    });
+  });
 });

--- a/tests/constants-e2e.ts
+++ b/tests/constants-e2e.ts
@@ -902,6 +902,10 @@ export const Tokens: {
       address: '0x2d0e0814e62d80056181f5cd932274405966e4f0',
       decimals: 18,
     },
+    OS: {
+      address: '0xb1e25689d55734fd3fffc939c4c3eb52dff8a794',
+      decimals: 18,
+    },
   },
   [Network.BSC]: {
     POPS: {
@@ -2269,6 +2273,10 @@ export const Holders: {
     DAI: '0x90347b9CC81a4a28aAc74E8B134040d5ce2eaB6D',
   },
   [Network.UNICHAIN]: {},
+  [Network.SONIC]: {
+    OS: '0xb1e25689D55734FD3ffFc939c4C3Eb52DFf8A794',
+    WS: '0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38',
+  },
 };
 
 export const NativeTokenSymbols: { [network: number]: string } = {


### PR DESCRIPTION
This PR adds support for a new pool on OSwap dex: Origin’s Automated Redemption Manager (ARM) on Sonic

I have encountered multiple issues for running the tests on the existing dexes, I tried to stick as much as I could to the existing patterns in order to minimize the overhead of adding this pool.
Let me know if there's any additional work required to make this pass!
