### PR TITLE
Fix/bunni v2 latency

### DIFF
--- a/src/dex/bunni-v2/bunni-v2-pool.ts
+++ b/src/dex/bunni-v2/bunni-v2-pool.ts
@@ -20,6 +20,7 @@ import { deposit, withdraw } from './logic/BunniHubLogic';
 import {
   generateOnChainState,
   updateCuratorFees,
+  updatePoolTotalValueLocked,
   updateStateAfterDeposit,
   updateStateAfterNewBunni,
   updateStateAfterOrderFulfilled,
@@ -882,12 +883,25 @@ export class BunniV2EventPool extends StatefulEventSubscriber<ProtocolState> {
     );
   }
 
-  async _updateVaultSharePrices(): Promise<void> {
+  async _updatePoolTotalValueLocked(blockNumber?: number): Promise<void> {
+    const _blockNumber =
+      blockNumber || this.dexHelper.blockManager.getLatestBlockNumber();
+
     if (this.state !== null) {
-      await updateVaultSharePrices(
-        Object.values(this.state.vaultStates),
-        this.dexHelper,
-      );
+      const newState = _.cloneDeep(this.state) as ProtocolState;
+      await updatePoolTotalValueLocked(newState, this.dexHelper);
+      this.setState(newState, _blockNumber);
+    }
+  }
+
+  async _updateVaultSharePrices(blockNumber?: number): Promise<void> {
+    const _blockNumber =
+      blockNumber || this.dexHelper.blockManager.getLatestBlockNumber();
+
+    if (this.state !== null) {
+      const newState = _.cloneDeep(this.state) as ProtocolState;
+      await updateVaultSharePrices(newState, this.dexHelper);
+      this.setState(newState, _blockNumber);
     }
   }
 

--- a/src/dex/bunni-v2/bunni-v2-pool.ts
+++ b/src/dex/bunni-v2/bunni-v2-pool.ts
@@ -38,7 +38,7 @@ import PoolManagerABI from '../../abi/bunni-v2/PoolManager.abi.json';
 
 import { TickMath } from './lib/TickMath';
 import { _updateAmAmmWrite } from './logic/AmAmm';
-import { ZERO_BYTES_32 } from './lib/Constants';
+import { WAD, ZERO_BYTES_32 } from './lib/Constants';
 import { NULL_ADDRESS } from '../../constants';
 import { quoteSwap } from './logic/BunniQuoter';
 
@@ -410,8 +410,7 @@ export class BunniV2EventPool extends StatefulEventSubscriber<ProtocolState> {
     }
 
     // update the total supply (always 1e18 on the first deposit)
-    newPoolState.totalSupply +=
-      newPoolState.totalSupply === 0n ? 1_000_000_000_000_000_000n : shares;
+    newPoolState.totalSupply += newPoolState.totalSupply === 0n ? WAD : shares;
 
     newState.poolStates[poolId] = newPoolState;
     return newState;

--- a/src/dex/bunni-v2/bunni-v2.ts
+++ b/src/dex/bunni-v2/bunni-v2.ts
@@ -51,6 +51,7 @@ import {
 import ERC4626ABI from '../../abi//ERC4626.json';
 import { TickMath } from './lib/TickMath';
 import { formatUnits } from 'ethers/lib/utils';
+import { MIN_INITIAL_SHARES } from './lib/Constants';
 
 const VAULT_SHARE_PRICES_UPDATE_TTL = 1 * 60; // 1 minute
 const BUNNI_V2_GAS_COST = 400_000; // https://dashboard.tenderly.co/shared/simulation/d343cb5e-7d7c-45f8-9653-6a7f7f104eed/gas-usage
@@ -189,8 +190,9 @@ export class BunniV2 extends SimpleExchange implements IDex<BunniV2Data> {
       const token1 = pool.key.currency1.toLowerCase();
 
       return (
-        (matchesSrcToken(token0) && matchesDestToken(token1)) ||
-        (matchesSrcToken(token1) && matchesDestToken(token0))
+        pool.totalSupply > MIN_INITIAL_SHARES &&
+        ((matchesSrcToken(token0) && matchesDestToken(token1)) ||
+          (matchesSrcToken(token1) && matchesDestToken(token0)))
       );
     }) as PoolState[];
   }

--- a/src/dex/bunni-v2/lib/Constants.ts
+++ b/src/dex/bunni-v2/lib/Constants.ts
@@ -13,3 +13,4 @@ export const LN2_WAD: bigint = 693147180559945309n;
 export const Q96: bigint = 2n ** 96n;
 export const MAX_INT_128: bigint = 2n ** 127n - 1n;
 export const MIN_INT_128: bigint = -(2n ** 127n);
+export const MIN_INITIAL_SHARES: bigint = 1_000_000_000_000n;

--- a/src/dex/bunni-v2/types.ts
+++ b/src/dex/bunni-v2/types.ts
@@ -46,6 +46,7 @@ export type Slot0 = {
 };
 
 export type MutablePoolState = {
+  totalValueLockedUSD: bigint;
   rawBalance0: bigint;
   rawBalance1: bigint;
   reserve0: bigint;

--- a/src/dex/bunni-v2/utils.ts
+++ b/src/dex/bunni-v2/utils.ts
@@ -176,6 +176,7 @@ export function initializePoolState(
       lastSurgeTimestamp: 0n,
     },
 
+    totalValueLockedUSD: 0n,
     rawBalance0: 0n,
     rawBalance1: 0n,
     reserve0: 0n,


### PR DESCRIPTION
Implements several fixes to attempt to reduce latency of the Bunni v2 dex:

1. Refactor block timestamp calls into a (maximum) single call per quote request.
2. Enforce minimum initial shares for pools to be included in pricing requests.
3. Enfore minimum TVL requirement for pools to be included in pricing requests.