### PR TITLE
feat: update bebop dex to support router

### DIFF
--- a/src/dex/bebop/bebop-integration.test.ts
+++ b/src/dex/bebop/bebop-integration.test.ts
@@ -291,8 +291,8 @@ describe('Bebop', function () {
           approvalTarget: routerAddress,
           buyTokens: {
             [usdcAddress]: {
-              amount: requestCount === 1 ? '1000000000' : '980000000',
-              minimumAmount: '980000000',
+              amount: '1000000000',
+              minimumAmount: requestCount === 1 ? '990000000' : '980000000',
             },
           },
           sellTokens: {

--- a/src/dex/bebop/bebop-integration.test.ts
+++ b/src/dex/bebop/bebop-integration.test.ts
@@ -3,6 +3,8 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 import { Interface, Result } from '@ethersproject/abi';
+import BigNumber from 'bignumber.js';
+import { utils } from 'ethers';
 import { DummyDexHelper } from '../../dex-helper/index';
 import { Network, SwapSide } from '../../constants';
 import { BI_POWS } from '../../bigint-constants';
@@ -111,7 +113,7 @@ describe('Bebop', function () {
     });
 
     afterAll(async () => {
-      if (bebop.releaseResources) {
+      if (bebop?.releaseResources) {
         await bebop.releaseResources();
       }
     });
@@ -177,6 +179,170 @@ describe('Bebop', function () {
       console.log('WETH -> ETH Pool Identifiers: ', pools);
 
       expect(pools.length).toBe(0);
+    });
+  });
+
+  describe('DexParam Generation', () => {
+    const network = Network.MAINNET;
+    const dexHelper = new DummyDexHelper(network);
+    const tokens = Tokens[network];
+    const bebop = new Bebop(network, dexKey, dexHelper);
+    const routerAddress = '0xBeb0009ACa35087ce7cCF11637E24dd1Aad3bf2A';
+    const settlementAddress = '0xbbbbbBB520d69a9775E85b458C58c648259FAD5F';
+    const userAddress = '0x5Bad996643a924De21b6b2875c85C33F3c5bBcB6';
+    const routerCalldata =
+      '0xa3ce737f' + '0'.repeat(64) + '1'.padStart(64, '0');
+
+    it('uses returned router tx target and approval target', () => {
+      const data = {
+        approvalTarget: settlementAddress,
+        partialFillOffset: 1,
+        tx: {
+          to: routerAddress,
+          value: '0x0',
+          data: routerCalldata,
+        },
+      };
+
+      const dexParam = bebop.getDexParam(
+        tokens['WETH'].address,
+        tokens['USDC'].address,
+        '1000000000000000000',
+        '1000000000',
+        userAddress,
+        data,
+        SwapSide.SELL,
+      );
+
+      expect(dexParam.targetExchange).toBe(utils.getAddress(routerAddress));
+      expect(dexParam.spender).toBe(utils.getAddress(settlementAddress));
+      expect(dexParam.exchangeData).toBe(routerCalldata);
+      expect(dexParam.insertFromAmountPos).toBe(36);
+    });
+
+    it('does not infer a dynamic amount position without partialFillOffset', () => {
+      const data = {
+        approvalTarget: routerAddress,
+        tx: {
+          to: routerAddress,
+          value: '0x0',
+          data: routerCalldata,
+        },
+      };
+
+      const dexParam = bebop.getDexParam(
+        tokens['WETH'].address,
+        tokens['USDC'].address,
+        '1000000000000000000',
+        '1000000000',
+        userAddress,
+        data,
+        SwapSide.SELL,
+      );
+
+      expect(dexParam.targetExchange).toBe(utils.getAddress(routerAddress));
+      expect(dexParam.spender).toBe(utils.getAddress(routerAddress));
+      expect(dexParam.swappedAmountNotPresentInExchangeData).toBe(true);
+      expect(dexParam.insertFromAmountPos).toBeUndefined();
+    });
+
+    it('does not insert sell amount into router buy calldata', () => {
+      const data = {
+        approvalTarget: routerAddress,
+        partialFillOffset: 1,
+        tx: {
+          to: routerAddress,
+          value: '0x0',
+          data: routerCalldata,
+        },
+      };
+
+      const dexParam = bebop.getDexParam(
+        tokens['WETH'].address,
+        tokens['USDC'].address,
+        '1000000000000000000',
+        '1000000000',
+        userAddress,
+        data,
+        SwapSide.BUY,
+      );
+
+      expect(dexParam.targetExchange).toBe(utils.getAddress(routerAddress));
+      expect(dexParam.spender).toBe(utils.getAddress(routerAddress));
+      expect(dexParam.swappedAmountNotPresentInExchangeData).toBe(true);
+      expect(dexParam.insertFromAmountPos).toBeUndefined();
+    });
+
+    it('passes slippage to quote request and validates firm amount', async () => {
+      const localDexHelper = new DummyDexHelper(network);
+      const localBebop = new Bebop(network, dexKey, localDexHelper);
+      const wethAddress = utils.getAddress(tokens['WETH'].address);
+      const usdcAddress = utils.getAddress(tokens['USDC'].address);
+      let requestCount = 0;
+
+      const getMock = jest.fn(async (url: string) => {
+        expect(decodeURIComponent(url)).toContain('slippage=1');
+        requestCount += 1;
+
+        return {
+          requestId: 'request-id',
+          quoteId: 'quote-id',
+          expiry: Math.floor(Date.now() / 1000) + 60,
+          approvalTarget: routerAddress,
+          buyTokens: {
+            [usdcAddress]: {
+              amount: requestCount === 1 ? '1000000000' : '980000000',
+              minimumAmount: '980000000',
+            },
+          },
+          sellTokens: {
+            [wethAddress]: {
+              amount: '1000000000000000000',
+            },
+          },
+          tx: {
+            to: routerAddress,
+            value: '0x0',
+            data: routerCalldata,
+          },
+        };
+      });
+
+      (localDexHelper.httpRequest.get as any) = getMock;
+
+      const params = {
+        srcAmount: '1000000000000000000',
+        destAmount: '1000000000',
+      } as any;
+      const options = {
+        slippageFactor: new BigNumber('0.99'),
+        txOrigin: userAddress,
+        userAddress,
+        executionContractAddress: userAddress,
+        recipient: userAddress,
+      } as any;
+
+      await expect(
+        localBebop.preProcessTransaction(
+          params,
+          tokens['WETH'],
+          tokens['USDC'],
+          SwapSide.SELL,
+          options,
+        ),
+      ).resolves.toBeDefined();
+
+      await expect(
+        localBebop.preProcessTransaction(
+          params,
+          tokens['WETH'],
+          tokens['USDC'],
+          SwapSide.SELL,
+          options,
+        ),
+      ).rejects.toThrow(/SlippageCheckError/);
+
+      expect(getMock).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/dex/bebop/bebop.ts
+++ b/src/dex/bebop/bebop.ts
@@ -211,7 +211,14 @@ export class Bebop
       `${this.dexKey}-${this.network}: invalid partialFillOffset ${data.partialFillOffset}`,
     );
 
-    return 4 + data.partialFillOffset * 32;
+    const amountPos = 4 + data.partialFillOffset * 32;
+
+    assert(
+      amountPos <= 0xffff,
+      `${this.dexKey}-${this.network}: partialFillOffset ${data.partialFillOffset} results in insertFromAmountPos ${amountPos} > 65535`,
+    );
+
+    return amountPos;
   }
 
   private async waitForInitialState(timeoutMs: number): Promise<void> {

--- a/src/dex/bebop/bebop.ts
+++ b/src/dex/bebop/bebop.ts
@@ -23,6 +23,7 @@ import {
   BebopLevel,
   BebopPair,
   BebopPricingResponse,
+  BebopTokenAmount,
   RoutingInstruction,
   TokenDataMap,
 } from './types';
@@ -140,10 +141,90 @@ export class Bebop
     );
   }
 
+  private getTokenAmount(
+    amounts: { [address: string]: BebopTokenAmount },
+    tokenAddress: Address,
+  ): BebopTokenAmount {
+    const checksumAddress = utils.getAddress(tokenAddress);
+    const tokenAmount =
+      amounts[checksumAddress] ||
+      Object.entries(amounts).find(
+        ([address]) => address.toLowerCase() === checksumAddress.toLowerCase(),
+      )?.[1];
+
+    assert(
+      tokenAmount !== undefined,
+      `${this.dexKey}-${this.network}: token amount missing for ${checksumAddress}`,
+    );
+
+    return tokenAmount;
+  }
+
+  private getQuoteSlippage(side: SwapSide, slippageFactor: BigNumber): string {
+    const slippage =
+      side === SwapSide.SELL
+        ? new BigNumber(1).minus(slippageFactor)
+        : slippageFactor.minus(1);
+
+    return slippage.gt(0) ? slippage.multipliedBy(100).toFixed() : '0';
+  }
+
+  private getTransactionTarget(data: BebopData): Address {
+    assert(data.tx?.to, `${this.dexKey}-${this.network}: tx.to undefined`);
+
+    return utils.getAddress(data.tx.to);
+  }
+
+  private getApprovalTarget(data: BebopData): Address {
+    assert(
+      data.approvalTarget,
+      `${this.dexKey}-${this.network}: approvalTarget undefined`,
+    );
+
+    return utils.getAddress(data.approvalTarget);
+  }
+
+  private getPartialFillAmountPos(data: BebopData): number | undefined {
+    if (
+      data.partialFillOffset === undefined ||
+      data.partialFillOffset === null
+    ) {
+      return undefined;
+    }
+
+    assert(
+      Number.isInteger(data.partialFillOffset) && data.partialFillOffset >= 0,
+      `${this.dexKey}-${this.network}: invalid partialFillOffset ${data.partialFillOffset}`,
+    );
+
+    return 4 + data.partialFillOffset * 32;
+  }
+
+  private async waitForInitialState(timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const [prices, tokens] = await Promise.all([
+        this.getCachedPrices(),
+        this.getCachedTokens(),
+      ]);
+
+      if (prices && tokens) {
+        return;
+      }
+
+      await sleep(250);
+    }
+
+    this.logger.warn(
+      `${this.dexKey}-${this.network}: initial pricing state was not ready after ${timeoutMs}ms`,
+    );
+  }
+
   async initializePricing(blockNumber: number) {
     if (!this.dexHelper.config.isSlave) {
       this.rateFetcher.start();
-      await sleep(BEBOP_INIT_TIMEOUT_MS);
+      await this.waitForInitialState(BEBOP_INIT_TIMEOUT_MS);
     }
 
     await this.setTokensMap();
@@ -555,7 +636,7 @@ export class Bebop
     const payload = tx.data;
 
     return {
-      targetExchange: this.settlementAddress,
+      targetExchange: this.getTransactionTarget(data),
       payload,
       networkFee: '0',
     };
@@ -585,7 +666,9 @@ export class Bebop
     _tokenAddress: Address,
     limit: number,
   ): Promise<PoolLiquidity[]> {
-    const tokenAddress = _tokenAddress.toLowerCase();
+    const normalizedTokenAddress = this.dexHelper.config
+      .wrapETH(_tokenAddress)
+      .toLowerCase();
     const prices = await this.getCachedPrices();
 
     if (!prices) {
@@ -600,8 +683,8 @@ export class Bebop
       let token;
       const [base, quote] = pair.split('/').map(t => t.toLowerCase());
 
-      const isBase = base == tokenAddress;
-      const isQuote = quote == tokenAddress;
+      const isBase = base == normalizedTokenAddress;
+      const isQuote = quote == normalizedTokenAddress;
 
       // There is pricing for token is not enabled at the moment
       if (!(quote in this.tokensMap && base in this.tokensMap)) {
@@ -677,6 +760,10 @@ export class Bebop
     const { tx } = data;
 
     assert(tx !== undefined, `${this.dexKey}-${this.network}: tx undefined`);
+    assert(tx.data, `${this.dexKey}-${this.network}: tx.data undefined`);
+
+    const targetExchange = this.getTransactionTarget(data);
+    const spender = this.getApprovalTarget(data);
 
     const isSwapSingle = tx.data.slice(0, 10) === SWAP_SINGLE_METHOD_SELECTOR;
     const isSwapAggregate =
@@ -714,14 +801,34 @@ export class Bebop
         exchangeData: exchangeData,
         needWrapNative: this.needWrapNative,
         dexFuncHasRecipient: true,
-        targetExchange: this.settlementAddress,
+        targetExchange,
+        spender,
         returnAmountPos: undefined,
         sendEthButSupportsInsertFromAmount: true,
         insertFromAmountPos: filledTakerAmountPos,
       };
-    } else {
-      throw new Error('Not supported method');
     }
+
+    const partialFillAmountPos = this.getPartialFillAmountPos(data);
+    const canInsertPartialFillAmount =
+      side === SwapSide.SELL && partialFillAmountPos !== undefined;
+
+    return {
+      exchangeData: tx.data,
+      needWrapNative: this.needWrapNative,
+      dexFuncHasRecipient: true,
+      targetExchange,
+      spender,
+      returnAmountPos: undefined,
+      ...(canInsertPartialFillAmount
+        ? {
+            sendEthButSupportsInsertFromAmount: true,
+            insertFromAmountPos: partialFillAmountPos,
+          }
+        : {
+            swappedAmountNotPresentInExchangeData: true,
+          }),
+    };
   }
 
   async preProcessTransaction(
@@ -748,6 +855,7 @@ export class Bebop
       gasless: false,
       skip_validation: true,
       source: this.bebopAuthName,
+      slippage: this.getQuoteSlippage(side, options.slippageFactor),
     };
 
     let requestId: string | undefined;
@@ -785,8 +893,11 @@ export class Bebop
 
       if (
         !response.tx ||
+        !response.tx.to ||
+        !response.tx.data ||
         !response.buyTokens ||
         !response.sellTokens ||
+        !response.approvalTarget ||
         !response.expiry
       ) {
         const baseMessage = `Bebop quote failed on chain ${this.network} Sell: ${params.sell_tokens}. Buy: ${params.buy_tokens}.`;
@@ -803,8 +914,11 @@ export class Bebop
 
       if (side === SwapSide.SELL) {
         const requiredAmount = optimalSwapExchange.destAmount;
-        const quoteAmount =
-          response.buyTokens[utils.getAddress(destToken.address)].amount;
+        const quoteTokenAmount = this.getTokenAmount(
+          response.buyTokens,
+          destToken.address,
+        );
+        const quoteAmount = quoteTokenAmount.amount;
 
         const requiredAmountWithSlippage = new BigNumber(requiredAmount)
           .times(options.slippageFactor)
@@ -822,8 +936,10 @@ export class Bebop
         }
       } else {
         const requiredAmount = optimalSwapExchange.srcAmount;
-        const quoteAmount =
-          response.sellTokens[utils.getAddress(srcToken.address)].amount;
+        const quoteAmount = this.getTokenAmount(
+          response.sellTokens,
+          srcToken.address,
+        ).amount;
 
         const requiredAmountWithSlippage = new BigNumber(requiredAmount)
           .times(options.slippageFactor)

--- a/src/dex/bebop/bebop.ts
+++ b/src/dex/bebop/bebop.ts
@@ -160,6 +160,20 @@ export class Bebop
     return tokenAmount;
   }
 
+  private getTokenMinimumAmount(
+    tokenAmount: BebopTokenAmount,
+    tokenAddress: Address,
+  ): string {
+    assert(
+      tokenAmount.minimumAmount !== undefined,
+      `${this.dexKey}-${
+        this.network
+      }: minimum amount missing for ${utils.getAddress(tokenAddress)}`,
+    );
+
+    return tokenAmount.minimumAmount;
+  }
+
   private getQuoteSlippage(side: SwapSide, slippageFactor: BigNumber): string {
     const slippage =
       side === SwapSide.SELL
@@ -918,19 +932,22 @@ export class Bebop
           response.buyTokens,
           destToken.address,
         );
-        const quoteAmount = quoteTokenAmount.amount;
+        const quoteMinimumAmount = this.getTokenMinimumAmount(
+          quoteTokenAmount,
+          destToken.address,
+        );
 
         const requiredAmountWithSlippage = new BigNumber(requiredAmount)
           .times(options.slippageFactor)
           .toFixed(0);
 
-        if (BigInt(quoteAmount) < BigInt(requiredAmountWithSlippage)) {
+        if (BigInt(quoteMinimumAmount) < BigInt(requiredAmountWithSlippage)) {
           throw new SlippageCheckError(
             this.dexKey,
             this.network,
             side,
             requiredAmountWithSlippage,
-            quoteAmount,
+            quoteMinimumAmount,
             options.slippageFactor,
           );
         }

--- a/src/dex/bebop/types.ts
+++ b/src/dex/bebop/types.ts
@@ -47,16 +47,19 @@ export type BebopPricingResponse = {
 };
 
 export interface BebopTx {
+  chainId?: number;
   to: string;
   value: string;
   data: string;
-  from: string;
-  gas: number;
+  from?: string | null;
+  gas?: number | null;
+  gasPrice?: number | null;
 }
 
 export type BebopTokenAmount = {
   amount: string;
-  priceUsd: number;
+  minimumAmount?: string;
+  priceUsd?: number | null;
 };
 
 export type BebopError = {
@@ -69,10 +72,14 @@ export type BebopData = {
   expiry?: number;
   buyTokens?: { [address: string]: BebopTokenAmount };
   sellTokens?: { [address: string]: BebopTokenAmount };
+  settlementAddress?: string;
+  approvalTarget?: string;
   tx?: BebopTx;
   error?: BebopError;
   quoteId?: string;
   requestId?: string;
+  chainId?: number;
+  partialFillOffset?: number | null;
 };
 
 export type DexParams = {


### PR DESCRIPTION
Updating to support router as per https://docs.bebop.xyz/rfq-api/guides/router-migration-guide

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes swap execution targets, approval spenders, and firm-quote slippage validation on a live DEX integration; misrouting or bad partial-fill offsets could break swaps or approvals.
> 
> **Overview**
> Migrates Bebop RFQ execution from a fixed settlement contract to **router-driven quotes**: swap targets and token approvals now come from the quote’s `tx.to` and `approvalTarget`, with router calldata handled via `partialFillOffset` for sell-side amount insertion when settlement-style selectors are not used.
> 
> Quote fetching now sends **`slippage`** to the v3 API, validates richer quote payloads (`tx.to`/`data`, `approvalTarget`), and enforces sell-side protection using each buy token’s **`minimumAmount`** (with case-insensitive token map lookup). Startup waits for cached **prices and tokens** instead of a fixed init sleep, and top-pool lookup **wraps native ETH** when matching pairs.
> 
> Adds integration tests for `getDexParam` routing/approval behavior and slippage in `preProcessTransaction`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eae63596f613f17ad185835790dee19721b84d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->