### PR TITLE
temp: disable multihop for curve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/index.ts
+++ b/src/dex/index.ts
@@ -236,7 +236,7 @@ export class DexAdapterService {
     balancerV2Merge,
     balancerV3Merge,
     uniswapMerge,
-    curveV1Merge,
+    // curveV1Merge,
     uniswapV4Merge,
   ];
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live swap route shaping for Curve V1 Factory/StableNg paths and may alter quotes and execution until re-enabled.
> 
> **Overview**
> **Temporarily disables Curve multihop** by removing `curveV1Merge` from `DexAdapterService.routeOptimizers` (left commented in `src/dex/index.ts`).
> 
> Without that optimizer, consecutive Curve V1 Factory / StableNg hops are no longer merged into a single multihop exchange step during route optimization. Curve swaps can still appear in routes, but not in the combined multihop form this merge produced.
> 
> Bumps `@paraswap/dex-lib` to **5.1.3** for release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0108009d25b6f95ed8b907644f61f5f5a82608d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->