### PR TITLE
feat(RingV2): add BSC support

### DIFF
--- a/src/dex/uniswap-v2/ring-v2.ts
+++ b/src/dex/uniswap-v2/ring-v2.ts
@@ -50,6 +50,14 @@ const RingV2Config: DexConfigMap<DexParams> = {
       feeCode: 30,
       router: '0x39d1d8fcC5E6EEAf567Bce4e29B94fec956D3519',
     },
+    [Network.BSC]: {
+      factoryAddress: '0x4De602A30Ad7fEf8223dcf67A9fB704324C4dd9B',
+      initCode:
+        '0xa7ae6a5ec37f0c21bbdac560794258c4089b8ae3ffa6e3909b53c6091764a676',
+      poolGasCost: 80 * 1000,
+      feeCode: 30,
+      router: '0x20504f37A95eF80e3FC7476c4801fb39AaE6bAd0',
+    },
   },
 };
 
@@ -60,6 +68,11 @@ const FewWrappedTokenConfig: DexConfigMap<{
   RingV2: {
     [Network.MAINNET]: {
       fewWrapFactory: '0x7D86394139bf1122E82FDF45Bb4e3b038A4464DD',
+      initCode:
+        '0x2bdba5734ddf754fb149ef1faa937956c52cfd1f24d68163a95f42d08ec06d38',
+    },
+    [Network.BSC]: {
+      fewWrapFactory: '0xEeE400Eabfba8F60f4e6B351D8577394BeB972CD',
       initCode:
         '0x2bdba5734ddf754fb149ef1faa937956c52cfd1f24d68163a95f42d08ec06d38',
     },

--- a/src/dex/uniswap-v2/uniswap-v2-e2e-bsc.test.ts
+++ b/src/dex/uniswap-v2/uniswap-v2-e2e-bsc.test.ts
@@ -525,4 +525,59 @@ describe('UniswapV2 E2E BSC', () => {
       });
     });
   });
+
+  describe('RingV2', () => {
+    jest.setTimeout(1000 * 60 * 3);
+
+    const dexKey = 'RingV2';
+
+    const sideToContractMethods = new Map([
+      [SwapSide.SELL, [ContractMethod.swapExactAmountIn]],
+      [SwapSide.BUY, [ContractMethod.swapExactAmountOut]],
+    ]);
+
+    const amounts: Record<string, string> = {
+      BNB: '1000000000000000',
+      ETH: '1000000000000000',
+    };
+
+    const pairs = [{ from: 'BNB', to: 'ETH' }];
+
+    sideToContractMethods.forEach((contractMethods, side) =>
+      describe(`${side}`, () => {
+        contractMethods.forEach((contractMethod: ContractMethod) => {
+          pairs.forEach(({ from, to }) => {
+            describe(`${contractMethod}`, () => {
+              it(`${from} -> ${to}`, async () => {
+                await testE2E(
+                  tokens[from],
+                  tokens[to],
+                  holders[from],
+                  side === SwapSide.SELL ? amounts[from] : amounts[to],
+                  side,
+                  dexKey,
+                  contractMethod,
+                  network,
+                  provider,
+                );
+              });
+              it(`${to} -> ${from}`, async () => {
+                await testE2E(
+                  tokens[to],
+                  tokens[from],
+                  holders[to],
+                  side === SwapSide.SELL ? amounts[to] : amounts[from],
+                  side,
+                  dexKey,
+                  contractMethod,
+                  network,
+                  provider,
+                );
+              });
+            });
+          });
+        });
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Add RingV2 deployment configuration for BSC.
- Add the BSC FewWrappedToken factory configuration.
- Add RingV2 BSC e2e coverage for BNB <-> ETH.

RingV2 already supports Ethereum. This PR only adds BSC configuration and tests.

## BSC deployments

- Ring Swap Factory: `0x4De602A30Ad7fEf8223dcf67A9fB704324C4dd9B`
- Few Factory: `0xEeE400Eabfba8F60f4e6B351D8577394BeB972CD`
- Ring Swap Router: `0x20504f37A95eF80e3FC7476c4801fb39AaE6bAd0`
- Ring Swap Pair Init Code: `0xa7ae6a5ec37f0c21bbdac560794258c4089b8ae3ffa6e3909b53c6091764a676`
- Few Wrapped Token Init Code: `0x2bdba5734ddf754fb149ef1faa937956c52cfd1f24d68163a95f42d08ec06d38`

## Tests

- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check src/dex/uniswap-v2/ring-v2.ts src/dex/uniswap-v2/uniswap-v2-e2e-bsc.test.ts`
- `pnpm run check:tsc`
- `pnpm run check:es`
- `pnpm run build`
- `git diff --check`
- `pnpm exec jest src/dex/uniswap-v2/uniswap-v2-e2e-bsc.test.ts --runInBand -t RingV2 --silent --forceExit`

## Notes

- `WBNB/ETH` has liquidity on RingV2 BSC, quotes in both directions, and is covered by the e2e tests.
- `WBNB/USDT` also quotes on-chain, but local e2e runs intermittently hit dex-lib's internal 3-second pricing timeout, so it is not included in the test coverage.
- `USDC/WBNB`, `bBTC/WBNB`, and `DAI/WBNB` were checked but do not currently have RingV2 pairs.
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New on-chain addresses on a live chain; misconfiguration would break routing or few-wrap resolution, but changes are additive config and tests mirroring mainnet.
> 
> **Overview**
> **RingV2** is extended to **BSC** by adding network-specific DEX config alongside the existing mainnet setup.
> 
> `RingV2Config` gains a `[Network.BSC]` entry with BSC factory and router addresses (same `initCode`, fee, and pool gas assumptions as mainnet). `FewWrappedTokenConfig` gets a matching BSC block so few-wrapped token CREATE2 addresses resolve with the BSC few-wrap factory. Because `dexKeysWithNetwork` is built from these maps, BSC is picked up without other wiring changes.
> 
> BSC **e2e** coverage is added in `uniswap-v2-e2e-bsc.test.ts`: RingV2 SELL/BUY via `swapExactAmountIn` / `swapExactAmountOut` for **BNB ↔ ETH** in both directions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104cb14af9ad03b14d75e381bbb08f518a138801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->