### PR TITLE
feat: add GlueHook V3 UniswapV4 hook (passthrough quoting, same address on all networks)

### DIFF
--- a/src/dex/uniswap-v4/config.ts
+++ b/src/dex/uniswap-v4/config.ts
@@ -2,6 +2,7 @@ import { DexConfigMap } from '../../types';
 import { Network } from '../../constants';
 import { DexParams, SubgraphPool } from './types';
 import { ArenaHook } from './hooks/arena/arena-hook';
+import { GlueHook } from './hooks/gluehook/gluehook-hook';
 
 export const UniswapV4Config: DexConfigMap<DexParams> = {
   UniswapV4: {
@@ -12,6 +13,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       router: '0x66a9893cc07d91d95644aedd05d03f95e1dba8af',
       stateView: '0x7ffe42c4a5deea5b0fec41c94c136cf115597227',
       stateMulticall: '0xDCf1849caCdfF839f93682262a04915f83a9dB0e',
+      supportedHooks: [GlueHook],
     },
     [Network.BASE]: {
       poolManager: '0x498581ff718922c3f8e6a244956af099b2652b2b',
@@ -22,6 +24,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       stateView: '0xa3c0c9b65bad0b08107aa264b0f3db444b867a71',
       skipPoolsWithUnconventionalFees: true,
       stateMulticall: '0x223c5fc295557f634979827728558424cf879d44',
+      supportedHooks: [GlueHook],
     },
     [Network.OPTIMISM]: {
       poolManager: '0x9a13f98cb987694c9f086b1f5eb990eea8264ec3',
@@ -30,6 +33,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       router: '0x851116d9223fabed8e56c0e6b8ad0c31d98b3507',
       stateView: '0xc18a3169788f4f75a170290584eca6395c75ecdb',
       stateMulticall: '0x4377Ead7BFC000711821934B72597bd700DD6E71',
+      supportedHooks: [GlueHook],
     },
     [Network.ARBITRUM]: {
       poolManager: '0x360e68faccca8ca495c1b759fd9eee466db9fb32',
@@ -38,6 +42,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       router: '0xa51afafe0263b40edaef0df8781ea9aa03e381a3',
       stateView: '0x76fd297e2d437cd7f76d50f01afe6160f86e9990',
       stateMulticall: '0x482cA248d91E08668efF568Ebb9805694D4DC396',
+      supportedHooks: [GlueHook],
     },
     [Network.POLYGON]: {
       poolManager: '0x67366782805870060151383f4bbff9dab53e5cd6',
@@ -46,6 +51,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       router: '0x1095692a6237d83c6a72f3f5efedb9a670c49223',
       stateView: '0x5ea1bd7974c8a611cbab0bdcafcb1d9cc9b3ba5a',
       stateMulticall: '0xA97349A3e17463EA840867937605Bb1D80cd2EE3',
+      supportedHooks: [GlueHook],
     },
     [Network.AVALANCHE]: {
       poolManager: '0x06380c0e0912312b5150364b9dc4542ba0dbbc85',
@@ -54,7 +60,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       router: '0x94b75331ae8d42c1b61065089b7d48fe14aa73b7',
       stateView: '0xc3c9e198c735a4b97e3e683f391ccbdd60b69286',
       stateMulticall: '0xf03feb5d6b26a68a773f1a77d7880fc5bdcc0581',
-      supportedHooks: [ArenaHook],
+      supportedHooks: [ArenaHook, GlueHook],
     },
     [Network.BSC]: {
       poolManager: '0x28e2ea090877bf75740558f6bfb36a5ffee9e9df',
@@ -63,6 +69,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       router: '0x1906c1d672b88cd1b9ac7593301ca990f94eae07',
       stateView: '0xd13dd3d6e93f276fafc9db9e6bb47c1180aee0c4',
       stateMulticall: '0x3f5ef7d58ed47135d9911600c1dc1d0f8601b039',
+      supportedHooks: [GlueHook],
     },
     [Network.UNICHAIN]: {
       poolManager: '0x1f98400000000000000000000000000000000004',
@@ -71,6 +78,7 @@ export const UniswapV4Config: DexConfigMap<DexParams> = {
       router: '0xef740bf23acae26f6492b10de645d6b98dc8eaf3',
       stateView: '0x86e8631a016f9068c3f085faf484ee3f5fdee8f2',
       stateMulticall: '0xf03fEb5d6B26a68a773f1a77d7880fc5BDcc0581',
+      supportedHooks: [GlueHook],
     },
   },
 };

--- a/src/dex/uniswap-v4/hooks/gluehook/config.ts
+++ b/src/dex/uniswap-v4/hooks/gluehook/config.ts
@@ -1,0 +1,19 @@
+import { HookConfig } from '../types';
+import { HookParams } from './types';
+import { Network } from '../../../../constants';
+
+// GlueHook is deployed via CREATE from a nonce-0 deployer, so it lives at the SAME
+// address on every chain (also live on Blast, Celo, Monad, X Layer, World Chain, Zora,
+// Soneium, MegaETH, Robinhood and Tempo beyond the networks configured here).
+const GLUEHOOK_ADDRESS = '0xb216070c3509047ea597e2e626a29cea427a60c8';
+
+export const GlueHookConfig: HookConfig<HookParams> = {
+  [Network.MAINNET]: { hookAddress: GLUEHOOK_ADDRESS },
+  [Network.BASE]: { hookAddress: GLUEHOOK_ADDRESS },
+  [Network.OPTIMISM]: { hookAddress: GLUEHOOK_ADDRESS },
+  [Network.ARBITRUM]: { hookAddress: GLUEHOOK_ADDRESS },
+  [Network.POLYGON]: { hookAddress: GLUEHOOK_ADDRESS },
+  [Network.AVALANCHE]: { hookAddress: GLUEHOOK_ADDRESS },
+  [Network.BSC]: { hookAddress: GLUEHOOK_ADDRESS },
+  [Network.UNICHAIN]: { hookAddress: GLUEHOOK_ADDRESS },
+};

--- a/src/dex/uniswap-v4/hooks/gluehook/config.ts
+++ b/src/dex/uniswap-v4/hooks/gluehook/config.ts
@@ -3,9 +3,9 @@ import { HookParams } from './types';
 import { Network } from '../../../../constants';
 
 // GlueHook is deployed via CREATE from a nonce-0 deployer, so it lives at the SAME
-// address on every chain (also live on Blast, Celo, Monad, X Layer, World Chain, Zora,
-// Soneium, MegaETH, Robinhood and Tempo beyond the networks configured here).
-const GLUEHOOK_ADDRESS = '0xb216070c3509047ea597e2e626a29cea427a60c8';
+// address on every chain (also live on X Layer, World Chain, Soneium, MegaETH and
+// Robinhood beyond the networks configured here).
+const GLUEHOOK_ADDRESS = '0x0f41715dc432692b66a5adf8dcfef6ac407b20c8';
 
 export const GlueHookConfig: HookConfig<HookParams> = {
   [Network.MAINNET]: { hookAddress: GLUEHOOK_ADDRESS },

--- a/src/dex/uniswap-v4/hooks/gluehook/gluehook-hook.test.ts
+++ b/src/dex/uniswap-v4/hooks/gluehook/gluehook-hook.test.ts
@@ -17,7 +17,7 @@ describe('GlueHook', () => {
       c.hookAddress.toLowerCase(),
     );
     expect(new Set(addresses).size).toBe(1);
-    expect(hook.address).toBe('0xb216070c3509047ea597e2e626a29cea427a60c8');
+    expect(hook.address).toBe('0x0f41715dc432692b66a5adf8dcfef6ac407b20c8');
   });
 
   it('afterSwap is a pure passthrough of the pool output (exact input)', () => {

--- a/src/dex/uniswap-v4/hooks/gluehook/gluehook-hook.test.ts
+++ b/src/dex/uniswap-v4/hooks/gluehook/gluehook-hook.test.ts
@@ -1,0 +1,86 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import { GlueHook } from './gluehook-hook';
+import { GlueHookConfig } from './config';
+import { Network } from '../../../../constants';
+import { PoolKey } from '../../types';
+
+const poolKey = {} as PoolKey;
+
+describe('GlueHook', () => {
+  const hook = new GlueHook(null as any, Network.BASE, console as any);
+
+  it('is configured with the same address on every supported network', () => {
+    const addresses = Object.values(GlueHookConfig).map(c =>
+      c.hookAddress.toLowerCase(),
+    );
+    expect(new Set(addresses).size).toBe(1);
+    expect(hook.address).toBe('0xb216070c3509047ea597e2e626a29cea427a60c8');
+  });
+
+  it('afterSwap is a pure passthrough of the pool output (exact input)', () => {
+    // zeroForOne exact-in: user receives amount1
+    expect(
+      hook.afterSwap(
+        '0x0000000000000000000000000000000000000000',
+        poolKey,
+        {
+          zeroForOne: true,
+          amountSpecified: (-1000000n).toString(),
+          sqrtPriceLimitX96: '0',
+        },
+        { amount0: -1000000n, amount1: 987654n },
+        '0x',
+      ),
+    ).toBe(987654n);
+
+    // oneForZero exact-in: user receives amount0
+    expect(
+      hook.afterSwap(
+        '0x0000000000000000000000000000000000000000',
+        poolKey,
+        {
+          zeroForOne: false,
+          amountSpecified: (-1000000n).toString(),
+          sqrtPriceLimitX96: '0',
+        },
+        { amount0: 987654n, amount1: -1000000n },
+        '0x',
+      ),
+    ).toBe(987654n);
+  });
+
+  it('afterSwap is a pure passthrough of the pool input (exact output)', () => {
+    // zeroForOne exact-out: user pays -amount0
+    expect(
+      hook.afterSwap(
+        '0x0000000000000000000000000000000000000000',
+        poolKey,
+        {
+          zeroForOne: true,
+          amountSpecified: (1000000n).toString(),
+          sqrtPriceLimitX96: '0',
+        },
+        { amount0: -1012345n, amount1: 1000000n },
+        '0x',
+      ),
+    ).toBe(1012345n);
+
+    // oneForZero exact-out: user pays -amount1
+    expect(
+      hook.afterSwap(
+        '0x0000000000000000000000000000000000000000',
+        poolKey,
+        {
+          zeroForOne: false,
+          amountSpecified: (1000000n).toString(),
+          sqrtPriceLimitX96: '0',
+        },
+        { amount0: 1000000n, amount1: -1012345n },
+        '0x',
+      ),
+    ).toBe(1012345n);
+  });
+});

--- a/src/dex/uniswap-v4/hooks/gluehook/gluehook-hook.ts
+++ b/src/dex/uniswap-v4/hooks/gluehook/gluehook-hook.ts
@@ -1,0 +1,87 @@
+import { IDexHelper } from '../../../../dex-helper';
+import { GlueHookConfig } from './config';
+import { Network } from '../../../../constants';
+import { Logger } from '../../../../types';
+import { PoolKey } from '../../types';
+import {
+  SwapParams,
+  BalanceDelta,
+  HooksPermissions,
+  IBaseHook,
+} from '../types';
+
+/**
+ * GlueHook (https://gluehook.trade) — a free, keyless, general-purpose hook that gives a
+ * pool a permissionless buyback pot (it buys after buys and can absorb sells) plus a
+ * self-compounding LP position owned by the hook itself.
+ *
+ * Quoting is a pure passthrough — the hook NEVER changes the swapper's amounts:
+ *  - Pump executes after the swap, spending the pot's own balance;
+ *  - Shield absorbs a sell while paying the seller the pool's EXACT output
+ *    (fee and tick impact included), so the quoted output is identical either way;
+ *  - auto-harvest / compound only moves the hook's own LP fees.
+ *
+ * Every hook action on-chain is wrapped in try/catch — a swap can never revert on hook
+ * state or settings. Standard V4 tick math therefore prices GlueHook pools exactly;
+ * `afterSwap` below returns the unmodified output.
+ *
+ * Deployed at the same address on every chain (CREATE from a nonce-0 deployer);
+ * verified everywhere. Source: https://github.com/glue-finance/GlueHook
+ */
+export class GlueHook implements IBaseHook {
+  readonly name = this.constructor.name;
+  readonly address: string;
+
+  constructor(
+    readonly dexHelper: IDexHelper,
+    readonly network: Network,
+    readonly logger: Logger,
+  ) {
+    this.address = GlueHookConfig[network].hookAddress.toLowerCase();
+  }
+
+  registerPool(_poolId: string, _poolKey: PoolKey) {
+    // stateless for quoting purposes — nothing to track per pool
+  }
+
+  async initialize(_blockNumber: number) {
+    // no off-chain state needed: amounts are vanilla-V4-exact by construction
+  }
+
+  getHookPermissions(): HooksPermissions {
+    // mirrors the on-chain flag bitmask 0x20C8
+    return {
+      beforeInitialize: true,
+      afterInitialize: false,
+      beforeAddLiquidity: false,
+      afterAddLiquidity: false,
+      beforeRemoveLiquidity: false,
+      afterRemoveLiquidity: false,
+      beforeSwap: true,
+      afterSwap: true,
+      beforeDonate: false,
+      afterDonate: false,
+      beforeSwapReturnDelta: true,
+      afterSwapReturnDelta: false,
+      afterAddLiquidityReturnDelta: false,
+      afterRemoveLiquidityReturnDelta: false,
+    };
+  }
+
+  afterSwap(
+    _sender: string,
+    _key: PoolKey,
+    params: SwapParams,
+    delta: BalanceDelta,
+    _hookData: string,
+  ): bigint {
+    // Pure passthrough: return the exact amount the pool's math produced.
+    const isExactInput = BigInt(params.amountSpecified) < 0n;
+    if (isExactInput) {
+      // amount the user receives
+      return params.zeroForOne ? delta.amount1 : delta.amount0;
+    }
+    // amount the user pays
+    return params.zeroForOne ? -delta.amount0 : -delta.amount1;
+  }
+}

--- a/src/dex/uniswap-v4/hooks/gluehook/types.ts
+++ b/src/dex/uniswap-v4/hooks/gluehook/types.ts
@@ -1,0 +1,5 @@
+import { Address } from '@paraswap/core';
+
+export type HookParams = {
+  hookAddress: Address;
+};


### PR DESCRIPTION
## What

Adds **GlueHook V3** as a supported UniswapV4 hook on all networks where the V4 integration is active (Mainnet, Base, Optimism, Arbitrum, Polygon, Avalanche, BSC, Unichain).

- New `src/dex/uniswap-v4/hooks/gluehook/` — `GlueHook` (`IBaseHook`), config, types, unit tests
- `src/dex/uniswap-v4/config.ts` — `supportedHooks: [GlueHook]` on the 8 active networks (appended next to `ArenaHook` on Avalanche)

**Address change vs the earlier revisions of this PR.** The first revision pointed at V1 (`0xb216…60C8`), the second at V2 (`0x0F41715dc432692b66A5aDF8dCfef6Ac407b20c8`). This revision **replaces that with the V3 deployment**, which is the hook new pools use:

| | Address | Bits |
|---|---|---|
| ~~V2 (previous revision)~~ | ~~`0x0F41715dc432692b66A5aDF8dCfef6Ac407b20c8`~~ | `0x20C8` |
| **V3 (this PR)** | **[`0x03d482cb3ff339c2d29736818d0f72c66dd6a040`](https://etherscan.io/address/0x03D482cB3Ff339C2d29736818D0F72c66dD6A040#code)** | `0x2040` |

Identical on every chain — deployed via `CREATE` from a nonce-0 deployer — and source-verified on each explorer. V1/V2 stay deployed for their own pools but are superseded and not configured here.

### What is GlueHook?

[GlueHook](https://gluehook.trade) is a **general-purpose Uniswap V4 hook** — not a platform-specific one. Any project, DAO or community attaches it to its own pool permissionlessly and gets, natively on Uniswap:

- **Buyback pot** — a permissionless per-pool treasury in the paired asset, fillable by anyone.
- **Pump** — behind every swap, in both directions, the pot buys the main asset at the pool's live price, sized by the pool's own fee × depth and paced against a time-weighted reference — no oracle, no keeper.
- **Burn cascade** — what the pot buys is delivered to the pot's recipient; `address(0)` means burn through the Glue Protocol.
- **Self-compounding LP** — the hook's own LP position auto-harvests its fees (swap-triggered) and splits them between autocompound, pot refuel, burn, and a recipient.

Infrastructure, not a product with privileged access: one deployment serves every pool, not upgradeable, no owner or admin keys, zero protocol fee, and **swaps can never be blocked** (every hook action is try/catch).

### Why V3 (what changed vs V1/V2)

Launch write-up with the full numbers: https://x.com/glue_fi/status/2100237021264450020

- **The pot can no longer empty itself in one transaction.** V1/V2 ran two modes — buying on buys and *defending* on sells — and the defence could spend 100% of the pot at whatever price was on screen. V3 turns the defence into a buy and puts a TWAP underneath it: the most it spends behind any one swap is `0.8·f·R` (0.8% of pool depth at a 1% pool), measured against its own ten-minute time-weighted reference. It buys in slices — hard into dips, pulling back as a rally runs ahead of the reference. Same money, more supply bought.
- **One mechanism, behind every swap, in both directions.** Behind a buyer it adds to the buy; behind a seller it buys the dip that seller just made. Traffic is the trigger and the pump runs inside the swapper's own transaction — nothing in the mempool to front-run.
- **20× to 67× harder to play.** The sandwich was already closed in V2 (a −40% loss on fees). V3 closes the other two doors: unlocking the pot costs 50% of it in fees instead of 2.5%, round-trip farming needs a bag of ~16% of pool depth instead of ~1.25%, a pushed premium `d` shrinks the pump to `f/d`, and the reference rises at most 3% a minute. Spend = `0.8 · min(f·R, f·R·bucket, s(d)·B, pot)` — derivations in the repo README ("The pump math").
- **The before-swap path is gone.** V3 runs on permission bits `0x2040` — `beforeInitialize` + `afterSwap` only. No `beforeSwap`, no return delta: the swapper's trade is the pool's plain execution and the buyback happens after it. **Quotes are exact** (vanilla V4 math, nothing to model), **swaps cannot be blocked** (every hook action is a try/catch self-call — a failing buyback is skipped, never the swap), **the surface shrank**.
- **Cheaper Glue integration.** Burns go through the Glue Protocol directly (wrapper-aware), and native programs stream live harvest data to Glue's staking/locking engines.

## Pricing logic

**Pure passthrough — the hook never changes the swapper's amounts**, so standard V4 tick math prices GlueHook pools exactly:

- the hook has **no `beforeSwap` and returns no delta** — the swapper's trade is the pool's plain execution;
- the *pump* is the hook's own swap in `afterSwap`, run through a try/catch self-call, spending the pot's own balance;
- auto-harvest/compound only moves the hook's own LP fees.

`afterSwap` therefore returns the unmodified pool output (mirroring the caller's exact-in/exact-out selection), and `getHookPermissions()` mirrors the on-chain bitmask `0x2040` (`beforeInitialize`, `afterSwap`). Routing through these pools carries no execution risk beyond a bounded gas overhead (idle ~10k; a firing pump ~+88k; in-swap harvest + compound ~+111k).

## Important contract addresses

- Hook (all chains): `0x03d482cb3ff339c2d29736818d0f72c66dd6a040` — V3, canonical
- Pools use the canonical Uniswap V4 PoolManager on each network (already configured in this repo)
- Superseded, still live for their own pools only: V2 `0x0f41715dc432692b66a5adf8dcfef6ac407b20c8`, V1 `0xb216070c3509047ea597e2e626a29cea427a60c8` — source, addresses and diffs in https://github.com/glue-finance/glueHook/tree/main/legacy

## How this was tested

- `tsc --noEmit` — clean
- `jest src/dex/uniswap-v4/hooks/gluehook` — 3/3 passing (single cross-network address; `afterSwap` passthrough in all four exact-in/exact-out × direction combinations)
- On-chain: a live V3 pool on each of the 14 mainnets, launched, swapped both ways through the Universal Router, LP added and 50% removed — PoolIds + `V4Quoter` output in Uniswap/routing-api#1414
- Contract-side behavior is covered by the project's Foundry suites incl. deterministic gas measurements and live-chain fork tests: https://github.com/glue-finance/glueHook/tree/main/audit

## References

- Uniswap routing-api allowlist PR (V3): Uniswap/routing-api#1414
- KyberSwap integration (V3): KyberNetwork/kyberswap-dex-lib#1672
- DefiLlama adapter (V3): DefiLlama/DefiLlama-Adapters#21025
- Uniswap hooklist registry: Uniswap/hooklist#4787 (Base) and one issue per chain

**Live metrics:** https://dune.com/lalilulel0x0869/gluehook-live
