### PR TITLE
feature/dexlib 206

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/pancakeswap-v3/pancakeswap-v3.ts
+++ b/src/dex/pancakeswap-v3/pancakeswap-v3.ts
@@ -12,6 +12,7 @@ import {
   NumberAsString,
   PoolPrices,
   DexExchangeParam,
+  GetDexParamOptions,
 } from '../../types';
 import { SwapSide, Network, CACHE_PREFIX } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
@@ -930,6 +931,8 @@ export class PancakeswapV3
     recipient: Address,
     data: UniswapV3Data,
     side: SwapSide,
+    executorAddress: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
     const swapFunction =
       side === SwapSide.SELL
@@ -942,14 +945,18 @@ export class PancakeswapV3
       side === SwapSide.SELL
         ? {
             recipient,
-            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+            deadline: getLocalDeadlineAsFriendlyPlaceholder(
+              options?.nowTimestampMs,
+            ),
             amountIn: srcAmount,
             amountOutMinimum: destAmount,
             path,
           }
         : {
             recipient,
-            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+            deadline: getLocalDeadlineAsFriendlyPlaceholder(
+              options?.nowTimestampMs,
+            ),
             amountOut: destAmount,
             amountInMaximum: srcAmount,
             path,


### PR DESCRIPTION
- **fix: use `nowTimestampMs` for pancake-swap-v3**
- **5.1.5**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to swap calldata deadline encoding in one DEX; no auth or pricing logic touched.
> 
> **Overview**
> Bumps **@paraswap/dex-lib** to **5.1.5**.
> 
> **PancakeSwap V3** `getDexParam` now matches the shared `IDex` signature (`executorAddress`, optional `GetDexParamOptions`) and sets router swap **deadlines** via `getLocalDeadlineAsFriendlyPlaceholder(options?.nowTimestampMs)` for both exact-in and exact-out paths, instead of always using the current wall clock at encode time.
> 
> That keeps off-chain deadline placeholders aligned with the timestamp the executor passes when building the transaction (same pattern as other DEX integrations).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24f28b5d0ae4e52a9a39fd1d306f285c4adcb28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->