### PR TITLE
fix: thread nowTimestampMs into getDexParam local deadlines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.10",
+  "version": "5.1.11-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.11-1",
+  "version": "5.1.11",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.11-0",
+  "version": "5.1.11-1",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/algebra-integral/algebra-integral.ts
+++ b/src/dex/algebra-integral/algebra-integral.ts
@@ -10,6 +10,7 @@ import {
   TransferFeeParams,
   Logger,
   DexExchangeParam,
+  GetDexParamOptions,
   NumberAsString,
 } from '../../types';
 import {
@@ -664,7 +665,12 @@ export class AlgebraIntegral
     recipient: Address,
     data: AlgebraIntegralData,
     side: SwapSide,
+    _executorAddress?: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
+    const deadline = getLocalDeadlineAsFriendlyPlaceholder(
+      options?.nowTimestampMs,
+    );
     let swapFunction;
     let swapFunctionParams;
 
@@ -679,7 +685,7 @@ export class AlgebraIntegral
       swapFunctionParams = {
         limitSqrtPrice: '0',
         recipient: recipient,
-        deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+        deadline,
         amountIn: srcAmount,
         amountOutMinimum: destAmount,
         tokenIn: data.path[0].tokenIn,
@@ -696,14 +702,14 @@ export class AlgebraIntegral
         side === SwapSide.SELL
           ? {
               recipient: recipient,
-              deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+              deadline,
               amountIn: srcAmount,
               amountOutMinimum: destAmount,
               path,
             }
           : {
               recipient: recipient,
-              deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+              deadline,
               amountOut: destAmount,
               amountInMaximum: srcAmount,
               path,

--- a/src/dex/algebra/algebra.ts
+++ b/src/dex/algebra/algebra.ts
@@ -14,6 +14,7 @@ import {
   PoolLiquidity,
   Token,
   DexExchangeParam,
+  GetDexParamOptions,
   NumberAsString,
 } from '../../types';
 import { SwapSide, Network, CACHE_PREFIX } from '../../constants';
@@ -897,7 +898,12 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
     recipient: Address,
     data: AlgebraData,
     side: SwapSide,
+    _executorAddress?: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
+    const deadline = getLocalDeadlineAsFriendlyPlaceholder(
+      options?.nowTimestampMs,
+    );
     let swapFunction;
     let swapFunctionParams;
 
@@ -912,7 +918,7 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
       swapFunctionParams = {
         limitSqrtPrice: '0',
         recipient: recipient,
-        deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+        deadline,
         amountIn: srcAmount,
         amountOutMinimum: destAmount,
         tokenIn: data.path[0].tokenIn,
@@ -928,14 +934,14 @@ export class Algebra extends SimpleExchange implements IDex<AlgebraData> {
         side === SwapSide.SELL
           ? {
               recipient: recipient,
-              deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+              deadline,
               amountIn: srcAmount,
               amountOutMinimum: destAmount,
               path,
             }
           : {
               recipient: recipient,
-              deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+              deadline,
               amountOut: destAmount,
               amountInMaximum: srcAmount,
               path,

--- a/src/dex/balancer-v2/balancer-v2.ts
+++ b/src/dex/balancer-v2/balancer-v2.ts
@@ -7,6 +7,7 @@ import {
   DexExchangeParam,
   ExchangePrices,
   ExchangeTxInfo,
+  GetDexParamOptions,
   Log,
   Logger,
   PoolLiquidity,
@@ -1212,6 +1213,7 @@ export class BalancerV2
     side: SwapSide,
     recipient: string,
     sender: string,
+    nowTimestampMs?: number,
   ): BalancerV2SwapParam {
     assert(data.swaps.length === 1, 'should have exactly one pool');
 
@@ -1238,7 +1240,7 @@ export class BalancerV2
       singleSwap,
       funds,
       side === SwapSide.SELL ? '1' : MAX_INT,
-      getLocalDeadlineAsFriendlyPlaceholder(),
+      getLocalDeadlineAsFriendlyPlaceholder(nowTimestampMs),
     ];
 
     return params;
@@ -1270,6 +1272,7 @@ export class BalancerV2
     recipient: string,
     sender: string,
     shouldWalkAssetsBackward?: boolean, // should do for all buy but prefer keep it under control
+    nowTimestampMs?: number,
   ): BalancerV2BatchSwapParam {
     let swapOffset = 0;
     let swaps: BalancerSwap[] = [];
@@ -1365,7 +1368,7 @@ export class BalancerV2
       shouldWalkAssetsBackward ? assets.reverse() : assets,
       funds,
       limits,
-      getLocalDeadlineAsFriendlyPlaceholder(),
+      getLocalDeadlineAsFriendlyPlaceholder(nowTimestampMs),
     ];
 
     return params;
@@ -1699,6 +1702,7 @@ export class BalancerV2
     rawData: OptimizedBalancerV2Data | BalancerV2Data,
     side: SwapSide,
     executor: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
     const data = this.toOptimizedData(rawData, srcAmount, destAmount, side);
 
@@ -1709,6 +1713,8 @@ export class BalancerV2
       side,
       recipient,
       side === SwapSide.SELL ? NULL_ADDRESS : executor,
+      undefined,
+      options?.nowTimestampMs,
     );
 
     const [, swaps] = balancerBatchSwapParam;
@@ -1722,6 +1728,7 @@ export class BalancerV2
         side,
         recipient,
         executor,
+        options?.nowTimestampMs,
       );
 
       const exchangeData = this.eventPools.vaultInterface.encodeFunctionData(

--- a/src/dex/cap/cap.ts
+++ b/src/dex/cap/cap.ts
@@ -8,6 +8,7 @@ import {
   Logger,
   NumberAsString,
   DexExchangeParam,
+  GetDexParamOptions,
 } from '../../types';
 import { SwapSide, Network, UNLIMITED_USD_LIQUIDITY } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
@@ -214,6 +215,8 @@ export class Cap extends SimpleExchange implements IDex<CapData> {
     recipient: Address,
     data: CapData,
     side: SwapSide,
+    _executorAddress?: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
     const functionName = data.isMint ? 'mint' : 'burn';
 
@@ -225,7 +228,7 @@ export class Cap extends SimpleExchange implements IDex<CapData> {
         srcAmount,
         '1', // minAmountOut
         recipient,
-        getLocalDeadlineAsFriendlyPlaceholder(),
+        getLocalDeadlineAsFriendlyPlaceholder(options?.nowTimestampMs),
       ]),
       targetExchange: data.vaultAddress,
       returnAmountPos: extractReturnAmountPosition(

--- a/src/dex/maverick-v1/maverick-v1.ts
+++ b/src/dex/maverick-v1/maverick-v1.ts
@@ -10,6 +10,7 @@ import {
   PoolLiquidity,
   Logger,
   DexExchangeParam,
+  GetDexParamOptions,
 } from '../../types';
 import { SwapSide, Network } from '../../constants';
 import { getDexKeysWithNetwork, getBigIntPow, isTruthy } from '../../utils';
@@ -369,7 +370,12 @@ export class MaverickV1
     recipient: Address,
     data: MaverickV1Data,
     side: SwapSide,
+    _executorAddress?: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
+    const deadline = getLocalDeadlineAsFriendlyPlaceholder(
+      options?.nowTimestampMs,
+    );
     const swapFunction =
       side === SwapSide.SELL
         ? MaverickV1Functions.exactInputSingle
@@ -379,7 +385,7 @@ export class MaverickV1
       side === SwapSide.SELL
         ? {
             recipient,
-            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+            deadline,
             amountIn: srcAmount,
             amountOutMinimum: destAmount,
             tokenIn: srcToken,
@@ -389,7 +395,7 @@ export class MaverickV1
           }
         : {
             recipient,
-            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+            deadline,
             amountOut: destAmount,
             amountInMaximum: srcAmount,
             tokenIn: srcToken,

--- a/src/dex/oswap/oswap.ts
+++ b/src/dex/oswap/oswap.ts
@@ -10,6 +10,7 @@ import {
   Logger,
   NumberAsString,
   DexExchangeParam,
+  GetDexParamOptions,
   TransferFeeParams,
 } from '../../types';
 import {
@@ -404,11 +405,14 @@ export class OSwap extends SimpleExchange implements IDex<OSwapData> {
     data: OSwapData,
     side: SwapSide,
     executorAddress: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
     let method: string;
     let args: any;
     let returnAmountPos: number | undefined = undefined;
-    const deadline = getLocalDeadlineAsFriendlyPlaceholder();
+    const deadline = getLocalDeadlineAsFriendlyPlaceholder(
+      options?.nowTimestampMs,
+    );
 
     if (side === SwapSide.SELL) {
       method = 'swapExactTokensForTokens';

--- a/src/dex/trader-joe-v2.1/base.ts
+++ b/src/dex/trader-joe-v2.1/base.ts
@@ -3,6 +3,7 @@ import {
   AdapterExchangeParam,
   Address,
   DexExchangeParam,
+  GetDexParamOptions,
   SimpleExchangeParam,
 } from '../../types';
 import { IDexTxBuilder } from '../idex';
@@ -119,13 +120,17 @@ export class BaseTraderJoeV2
     recipient: Address,
     data: TraderJoeV2Data,
     side: SwapSide,
+    _executorAddress?: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
     const swapFunction =
       side === SwapSide.SELL
         ? TraderJoeV2RouterFunctions.swapExactTokensForTokens
         : TraderJoeV2RouterFunctions.swapTokensForExactTokens;
 
-    const placeholder = getLocalDeadlineAsFriendlyPlaceholder();
+    const placeholder = getLocalDeadlineAsFriendlyPlaceholder(
+      options?.nowTimestampMs,
+    );
 
     const swapFunctionParams: TraderJoeV2RouterParam =
       side === SwapSide.SELL

--- a/src/dex/uniswap-v2/ring-v2.ts
+++ b/src/dex/uniswap-v2/ring-v2.ts
@@ -16,6 +16,7 @@ import {
   ExchangePrices,
   Address,
   DexExchangeParam,
+  GetDexParamOptions,
   NumberAsString,
   DexConfigMap,
   SimpleExchangeParam,
@@ -353,13 +354,15 @@ export class RingV2 extends UniswapV2 {
     recipient: Address,
     data: UniswapV2Data,
     side: SwapSide,
+    _executorAddress?: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
     let args: any[];
     let functionName: RingV2Functions;
 
     let ttl = 1200;
     const deadline = `0x${(
-      Math.floor(new Date().getTime() / 1000) + ttl
+      Math.floor((options?.nowTimestampMs ?? Date.now()) / 1000) + ttl
     ).toString(16)}`;
 
     if (side == SwapSide.SELL) {

--- a/src/dex/uniswap-v3.ts
+++ b/src/dex/uniswap-v3.ts
@@ -5,6 +5,7 @@ import {
   AdapterExchangeParam,
   Address,
   DexExchangeParam,
+  GetDexParamOptions,
   SimpleExchangeParam,
 } from '../types';
 import { IDexTxBuilder } from './idex';
@@ -194,7 +195,12 @@ export class UniswapV3
     recipient: Address,
     data: UniswapV3Data,
     side: SwapSide,
+    _executorAddress?: Address,
+    options?: GetDexParamOptions,
   ): DexExchangeParam {
+    const deadline = getLocalDeadlineAsFriendlyPlaceholder(
+      options?.nowTimestampMs,
+    );
     const swapFunction =
       side === SwapSide.SELL
         ? UniswapV3Functions.exactInput
@@ -206,14 +212,14 @@ export class UniswapV3
       side === SwapSide.SELL
         ? {
             recipient,
-            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+            deadline,
             amountIn: srcAmount,
             amountOutMinimum: destAmount,
             path,
           }
         : {
             recipient,
-            deadline: getLocalDeadlineAsFriendlyPlaceholder(),
+            deadline,
             amountOut: destAmount,
             amountInMaximum: srcAmount,
             path,


### PR DESCRIPTION
# Thread nowTimestampMs into every getDexParam deadline (paraswap-dex-lib)

## Problem

`getDexParam` embeds router deadlines via `getLocalDeadlineAsFriendlyPlaceholder()` — called **argless** in every dex, so the deadline always derives from that process's wall clock. The helper already accepts a `nowTimestampMs` argument (src/dex/simple-exchange.ts:33), and `GetDexParamOptions.nowTimestampMs` already reaches `getDexParam` as `options` — but no dex passes it through (`grep -rn "getLocalDeadlineAsFriendlyPlaceholder(.*nowTimestampMs" src/dex` → zero hits).

This breaks the ApiGo build comparison (paraswap-api#1727): api-go pins its LOCAL encoders to the forwarded `nowTimestampMs` (dexlib core `FriendlyDeadlineFromOptions`), but legs api-go encodes REMOTELY via the hopper `dex-param` endpoint get the hopper process's wall clock. The hopper call lands ~1s after the legacy build, so whenever the two clocks straddle a second boundary the embedded deadline differs by 1 and the calldata mismatches — a coin-flip false positive per deadline-bearing remote leg.

## Evidence

Prod mismatch `api_go_build_mismatch` uuid `5105a61a-52c1-4ea0-a5df-d7c3a4522ba8` (Arbitrum cbBTC→ETH megaswap): 247/249 calldata words identical; the 2 diffs are the two CamelotV3 legs' deadlines — legacy `0x6a9e75fa` (= floor(pinned nowTimestampMs/1000)+7d exactly), apiGo `0x6a9e75fb` (+1s). CamelotV3 = `src/dex/algebra/algebra.ts`, the only legs of that route api-go encodes via the hopper. Go-locally-encoded legs (uniswapv3, pancakeswapv3) all matched because dexlib-core honors the pin.

## Fix

In each dex's `getDexParam` path (and any helper it calls to build exchangeData), change
`getLocalDeadlineAsFriendlyPlaceholder()` → `getLocalDeadlineAsFriendlyPlaceholder(options?.nowTimestampMs)`,
adding the `options?: GetDexParamOptions` parameter where the signature lacks it (IDexTxBuilder already declares it — DEXLIB-255 era).

Scope: ONLY `getDexParam`-reachable call sites; `getAdapterParam`/`getSimpleParam` paths never run on the hopper and can stay argless. Audit each of (argless call counts per file):
algebra (7), uniswap-v3/uniswap-v3.ts (5), uniswap-v3.ts legacy (5), maverick-v1 (5), trader-joe-v2.1/base.ts (4), balancer-v2 (4), pancakeswap-v3 (3), algebra-integral (3), curve-v2 (2), curve-v1 (2), curve-v1-factory (2), oswap (1), cap (1).

Priority: `algebra.ts` (CamelotV3/QuickSwap — the observed prod mismatches), then the rest.

## Verification

- Unit: for each touched dex, `getDexParam` with `options.nowTimestampMs` pinned twice across a fake 1s clock jump → identical exchangeData.
- End-to-end: replay uuid `5105a61a-…` inputs against a hopper running the fix — the ApiGo comparison must report `ApiGo build matches`; watch `api_go_build_mismatch` growth rate drop to ~0 for deadline-only diffs (2-word diffs where both words are ±1s timestamps).

## References

- paraswap-api#1727 (compare mode), VeloraDEX/dexlib#151 (Go encoding), DEXLIB-255 (nowTimestampMs plumbing).
- dexlib core pins correctly: dexlib/core/pkg/dex/deadline.go `FriendlyDeadlineFromOptions`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches calldata encoding for many DEX swap paths; logic is limited to deadline derivation but incorrect pinning could still cause failed swaps or mismatched builds if callers pass wrong timestamps.
> 
> **Overview**
> **Pins swap deadlines in hopper-encoded `getDexParam` calldata** so remote encoding uses the same clock as ApiGo’s local build comparison, instead of each process’s wall time.
> 
> Across Algebra, Algebra Integral, Uniswap V3, Maverick V1, Trader Joe V2.1, Balancer V2, Cap, OSwap, and Ring V2, `getDexParam` now accepts `options?: GetDexParamOptions` (and passes `options?.nowTimestampMs` into `getLocalDeadlineAsFriendlyPlaceholder`, with Balancer helpers taking an explicit `nowTimestampMs`). **Ring V2** builds its hex deadline from the same optional pin rather than always calling `Date.now()`.
> 
> Package version bumps to **5.1.11**. Behavior when `nowTimestampMs` is omitted stays the same (falls back to `Date.now()`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89466993e61137fdfec74c5a7c08b30752cbe1b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->