### PR TITLE
fix: use global exchangeParams index in Executor02 buildVerticalBranchingFlag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.11",
+  "version": "5.1.12-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.12-0",
+  "version": "5.1.12",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/executor/Executor02BytecodeBuilder.ts
+++ b/src/executor/Executor02BytecodeBuilder.ts
@@ -1439,6 +1439,28 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
     });
   }
 
+  // Returns the index of the swap exchange in the exchangeParams array,
+  // which is flattened across all routes
+  private getGlobalSwapExchangeIndex(
+    priceRoute: OptimalRate,
+    targetSwapExchange: OptimalSwapExchange<any>,
+  ): number {
+    let index = 0;
+    let swapExchangeIndex = 0;
+    priceRoute.bestRoute.forEach(route =>
+      route.swaps.forEach(curSwap =>
+        curSwap.swapExchanges.forEach(se => {
+          if (Object.is(se, targetSwapExchange)) {
+            index = swapExchangeIndex;
+          }
+          swapExchangeIndex++;
+        }),
+      ),
+    );
+
+    return index;
+  }
+
   private anyDexOnSwapDoesntNeedWrapNative(
     priceRoute: OptimalRate,
     swap: OptimalSwap,
@@ -1446,20 +1468,8 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
   ): boolean {
     return swap.swapExchanges
       .map(curSe => {
-        let index = 0;
-        let swapExchangeIndex = 0;
-        priceRoute.bestRoute.map(route => {
-          route.swaps.map(curSwap =>
-            curSwap.swapExchanges.map(async se => {
-              if (Object.is(se, curSe)) {
-                index = swapExchangeIndex;
-              }
-              swapExchangeIndex++;
-            }),
-          );
-        });
-
-        const curExchangeParam = exchangeParams[index];
+        const curExchangeParam =
+          exchangeParams[this.getGlobalSwapExchangeIndex(priceRoute, curSe)];
 
         return !curExchangeParam.needWrapNative;
       })
@@ -1477,20 +1487,8 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
 
     return swap.swapExchanges
       .map(curSe => {
-        let index = 0;
-        let swapExchangeIndex = 0;
-        priceRoute.bestRoute.map(route => {
-          route.swaps.map(curSwap =>
-            curSwap.swapExchanges.map(async se => {
-              if (Object.is(se, curSe)) {
-                index = swapExchangeIndex;
-              }
-              swapExchangeIndex++;
-            }),
-          );
-        });
-
-        const curExchangeParam = exchangeParams[index];
+        const curExchangeParam =
+          exchangeParams[this.getGlobalSwapExchangeIndex(priceRoute, curSe)];
 
         return curExchangeParam.needWrapNative;
       })
@@ -1508,20 +1506,8 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
 
     return swap.swapExchanges
       .map(curSe => {
-        let index = 0;
-        let swapExchangeIndex = 0;
-        priceRoute.bestRoute.map(route => {
-          route.swaps.map(curSwap =>
-            curSwap.swapExchanges.map(async se => {
-              if (Object.is(se, curSe)) {
-                index = swapExchangeIndex;
-              }
-              swapExchangeIndex++;
-            }),
-          );
-        });
-
-        const curExchangeParam = exchangeParams[index];
+        const curExchangeParam =
+          exchangeParams[this.getGlobalSwapExchangeIndex(priceRoute, curSe)];
 
         return curExchangeParam.needWrapNative;
       })
@@ -1561,18 +1547,8 @@ export class Executor02BytecodeBuilder extends ExecutorBytecodeBuilder<
       const lastSwapExchanges = lastSwap.swapExchanges;
       const anyDexLastSwapNeedUnwrap = lastSwapExchanges
         .map(curSe => {
-          let index = 0;
-          let swapExchangeIndex = 0;
-          priceRoute.bestRoute[routeIndex].swaps.map(curSwap =>
-            curSwap.swapExchanges.map(async se => {
-              if (Object.is(se, curSe)) {
-                index = swapExchangeIndex;
-              }
-              swapExchangeIndex++;
-            }),
-          );
-
-          const curExchangeParam = exchangeParams[index];
+          const curExchangeParam =
+            exchangeParams[this.getGlobalSwapExchangeIndex(priceRoute, curSe)];
 
           return (
             curExchangeParam.needWrapNative && !curExchangeParam.wethAddress


### PR DESCRIPTION
## Problem

In `Executor02BytecodeBuilder.buildVerticalBranchingFlag`, the `anyDexLastSwapNeedUnwrap` computation located each last-swap exchange by scanning only `priceRoute.bestRoute[routeIndex]`, producing a **route-local** index — but then read from the global `exchangeParams` array, which is flattened across **all** routes.

For any megaswap route after the first, this reads a wrong exchange's `needWrapNative`/`wethAddress`. The flag then flips whenever the misread params disagree with the real last-swap exchange's params: typically emitting `3` (`INSERT_FROM_AMOUNT_DONT_CHECK_BALANCE_AFTER_SWAP`) where `11` (`INSERT_FROM_AMOUNT_CHECK_SRC_TOKEN_BALANCE_AFTER_SWAP`) is intended, and on fallback-group headers the same flag choice also flips `destTokenPos`.

Trigger shape: megaswap + ETH dest + `routeIndex > 0`. Both encodings happen to be valid on-chain (the flag only adds/skips a redundant post-swap balance check), which is why this went unnoticed — it surfaced via compare mode against the Go port, which computes the index globally and correctly.

The three sibling helpers (`anyDexOnSwapDoesntNeedWrapNative`, `everyDexOnSwapNeedWrapNative`, `everyDexOnSwapDoesntNeedWrapNative`) already scanned across all routes; this inline copy was the lone divergent one.

## Fix

- Extracted a shared `getGlobalSwapExchangeIndex(priceRoute, targetSwapExchange)` helper that scans `priceRoute.bestRoute` across all routes, matching the flattening order of `exchangeParams`.
- Replaced all four copy-pasted inline scans with it. The three sibling helpers are behavior-identical; only the `buildVerticalBranchingFlag` site changes behavior, and only for megaswap routes with `routeIndex > 0`.
- The `needWrapNative && !wethAddress` predicate is untouched — only the index computation changed.

## Tests

- `pnpm check:tsc`, prettier, eslint clean.
- `executor02-fallback-encoding.test.ts` passes.
- Compare mode against the Go port (`executor02.go`) now agrees on the previously divergent megaswap cases, including the `destTokenPos` flip on fallback-group headers.

Note: `executor02-bytecode-builder-snapshot.test.ts` fails to compile on clean `master` with pre-existing type errors in the test file itself (stale `DexExchangeParam[]` cast) — unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes on-chain executor encoding for multi-route swaps; prior wrong flags were still valid but could diverge from the Go port and affect post-swap balance-check behavior.
> 
> **Overview**
> Fixes incorrect **Executor02** bytecode flags on **megaswap** routes after the first leg by aligning swap-exchange lookups with the globally flattened `exchangeParams` array.
> 
> Adds `getGlobalSwapExchangeIndex` and uses it everywhere a swap exchange is mapped to `exchangeParams`, replacing four copy-pasted scans (including one that only walked the current route). The behavioral fix is in `buildVerticalBranchingFlag` for the last-swap unwrap check: megaswap + ETH destination + `routeIndex > 0` could pick the wrong `needWrapNative` / `wethAddress` and flip vertical-branching flags (and related fallback `destTokenPos`). The three wrap-native helper refactors are equivalent to before.
> 
> Bumps package version to **5.1.12**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ad1d30968ce2d47471a47bf9022d233d54e761. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->