### PR TITLE
fix: align BalancerV1 needWrapNative posture with getDexParam

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.12",
+  "version": "5.1.13-0",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.13-0",
+  "version": "5.1.13",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/balancer-v1/balancer-v1.ts
+++ b/src/dex/balancer-v1/balancer-v1.ts
@@ -15,7 +15,7 @@ import {
 import { MAX_UINT, Network, SUBGRAPH_TIMEOUT } from '../../constants';
 import * as CALLDATA_GAS_COST from '../../calldata-gas-cost';
 import { getBigIntPow, getDexKeysWithNetwork, isETHAddress } from '../../utils';
-import { IDex } from '../../dex/idex';
+import { IDex, NeedWrapNativeFunc } from '../../dex/idex';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import {
   BalancerFunctions,
@@ -81,7 +81,15 @@ export class BalancerV1
   protected eventPools: { [poolAddress: string]: BalancerV1EventPool } = {};
 
   readonly hasConstantPriceLargeAmounts = false;
-  readonly needWrapNative = false;
+  // Mirrors the swap-function choice in getDexParam: native-in/out swaps use
+  // the proxy's batchEthIn/OutSwapExactIn variants (raw ETH, no wrap), while a
+  // SELL with no native side uses batchSwapExactIn, which needs ERC-20/WETH.
+  // Declaring the same rule here keeps the advertised posture equal to the
+  // needWrapNative that getDexParam returns for every route shape.
+  readonly needWrapNative: NeedWrapNativeFunc = (priceRoute, swap) =>
+    priceRoute.side === SwapSide.SELL &&
+    !isETHAddress(swap.srcToken) &&
+    !isETHAddress(swap.destToken);
   readonly isFeeOnTransferSupported = false;
 
   public static dexKeysWithNetwork: { key: string; networks: Network[] }[] =
@@ -449,10 +457,7 @@ export class BalancerV1
     }
 
     return {
-      needWrapNative:
-        swapFunction === BalancerFunctions.batchSwapExactIn
-          ? true
-          : this.needWrapNative,
+      needWrapNative: swapFunction === BalancerFunctions.batchSwapExactIn,
       specialDexFlag,
       insertFromAmountPos,
       specialDexSupportsInsertFromAmount,


### PR DESCRIPTION
## Why

BalancerV1 disagrees with itself about its wrap posture: the class declares `readonly needWrapNative = false`, but `getDexParam` returns `needWrapNative: true` whenever the swap function is `batchSwapExactIn` — i.e. every SELL with no native side.

The legacy builder never notices (it consumes the per-call value and only uses the class posture for call-param derivation, where the disagreement happens to be inert). But the api-go raw builder pre-resolves the posture through the hopper advertisement — which reports the static `false` — and then cross-checks it against the returned param. Every SELL route with a BalancerV1 member at any position fails there with `needWrapNative mismatch: expected false, got true` (~3.4k failures per 6h on mainnet), which silently excludes those routes from the ApiGo build-parity compare.

## What

Declare the posture as a `NeedWrapNativeFunc` that mirrors `getDexParam`'s swap-function branch exactly:

- ETH-src / ETH-dest swaps → `batchEthIn/OutSwapExactIn` variants (raw ETH) → `false` (unchanged from today)
- SELL with no native side → `batchSwapExactIn` (ERC-20/WETH) → `true` (previously misreported as `false`)
- BUY → `false` (unchanged)

`getDexParam`'s return simplifies to `swapFunction === batchSwapExactIn` (the removed ternary's fallback branch always evaluated to `false`).

## Behavior impact

None on builds. Case analysis:
- native-side swaps: the function returns `false`, same as the old static field — call params and calldata identical.
- no-native SELL swaps: the pre-resolved value flips `false → true`, but with no native token `getDexCallsParams` is value-independent (`wrapETH` is identity, no WETH deposit accrues) and the executor reads the per-call value, which is unchanged. Calldata identical.
- pricing: untouched — the function is only consulted at build time; pricing paths don't evaluate it.

The hopper surface already advertises function-valued postures as `dynamic` and evaluates them with the swap context, so api-go's pre-resolve starts agreeing with the returned param with no other changes.

## Testing

- `tsc` clean; repro route (WETH → 0x08d967bb…, UniswapV2+BalancerV1 split) fails on current staging api-go with the mismatch and is expected to build after this lands.
- The executor snapshot suites fail to compile on master identically (pre-existing, unrelated).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Advertisement-only alignment with existing per-call wrap flags; no swap calldata or pricing logic changes described in the diff.
> 
> **Overview**
> **Fixes a static vs per-route mismatch** on Balancer V1: the DEX advertised `needWrapNative: false` while `getDexParam` returned `true` for non-native **SELL** paths that use `batchSwapExactIn`.
> 
> The class-level posture is now a **`NeedWrapNativeFunc`** that matches the swap-function rule—`true` only when the route is **SELL** and neither side is native ETH; native-in/out paths stay **`false`**. **`getDexParam`** returns `needWrapNative` as `swapFunction === batchSwapExactIn` instead of branching on the old static field.
> 
> This unblocks **api-go** hopper pre-resolve vs param cross-checks (no more `needWrapNative mismatch` on Balancer V1 SELL hops) without changing calldata or executor behavior for those routes. Package version bumps to **5.1.13**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7adfa49a1a8c25118d6e8d6bdc1a5280844a5a91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->