### PR TITLE
feat: upgrade native to v6

### DIFF
--- a/src/dex/native/config.ts
+++ b/src/dex/native/config.ts
@@ -5,19 +5,19 @@ import { DexParams } from './types';
 export const NativeConfig: DexConfigMap<DexParams> = {
   Native: {
     [Network.MAINNET]: {
-      routerAddress: '0x8a2ddc0461Fcf96F81a05529Bed540d4f1eb2a00',
+      routerAddress: '0x4777A6B3A9A889ABfd4C7666Bdd2a7AB633293be',
       chainName: 'ethereum',
     },
     [Network.BSC]: {
-      routerAddress: '0xF064b069Ed18Eb5c61159247C55C5af79B28a968',
+      routerAddress: '0x1fDED89D98CBeADd96a109D28689c2638025dad3',
       chainName: 'bsc',
     },
     [Network.ARBITRUM]: {
-      routerAddress: '0x0FC85a171bD0b53BF0bBace74F04B66170Ae3eAb',
+      routerAddress: '0x0183D055c77310aF03dCB397eFAA7E9cfB6dB59b',
       chainName: 'arbitrum',
     },
     [Network.BASE]: {
-      routerAddress: '0xaEC634d949df14Be76dC317504C7b9a6a8A5f576',
+      routerAddress: '0x9706D3fff42571305Fc201F996ADC0e768d72911',
       chainName: 'base',
     },
   },

--- a/src/dex/native/constants.ts
+++ b/src/dex/native/constants.ts
@@ -10,5 +10,6 @@ export const NATIVE_GAS_COST = 120_000;
 
 export const NATIVE_BLACKLIST_PAGE_SIZE = 35000;
 
-export const NATIVE_FIRM_QUOTE_VERSION = '4';
+export const NATIVE_FIRM_QUOTE_VERSION = '6';
 export const NATIVE_FIRM_QUOTE_EXPIRY_S = 60;
+export const NATIVE_TRADE_RFQT_SELECTOR = '0x7083527c';

--- a/src/dex/native/native-dex-param.test.ts
+++ b/src/dex/native/native-dex-param.test.ts
@@ -7,6 +7,7 @@ import { Network, SwapSide } from '../../constants';
 import { Tokens } from '../../../tests/constants-e2e';
 import { GetDexParamPreProcessOptions } from '../../types';
 import { Native } from './native';
+import { NATIVE_TRADE_RFQT_SELECTOR } from './constants';
 
 const dexKey = 'Native';
 const network = Network.MAINNET;
@@ -16,7 +17,7 @@ const routerAddress = '0x1111111254EEB25477B68fb85Ed929f73A960582';
 const userAddress = '0x5Bad996643a924De21b6b2875c85C33F3c5bBcB6';
 const executorAddress = '0x6A000F20005980200259B80c5102003040001068';
 // tradeRFQT selector — the only one Native infers insertFromAmountPos for
-const calldata = '0x0947c2d9' + '0'.repeat(64);
+const calldata = `${NATIVE_TRADE_RFQT_SELECTOR}${'0'.repeat(64)}`;
 
 const DEADLINE = 1893456000;
 
@@ -91,6 +92,17 @@ describe('Native getDexParam without preProcessTransaction', () => {
     const dexParam = await getDexParam(native, {}, { preProcess });
 
     expect(requestMock).toHaveBeenCalledTimes(1);
+    const requestParams = (
+      requestMock.mock.calls as unknown as Array<
+        [{ params: Record<string, string> }]
+      >
+    )[0][0].params;
+    expect(requestParams).toMatchObject({
+      version: '6',
+      execution_payer: executorAddress.toLowerCase(),
+      tx_origin: userAddress.toLowerCase(),
+      beneficiary_address: userAddress.toLowerCase(),
+    });
     expect(dexParam.exchangeData).toBe(calldata);
     expect(dexParam.targetExchange).toBe(routerAddress);
     expect(dexParam.minDeadline).toBe(String(DEADLINE));

--- a/src/dex/native/native-integration.test.ts
+++ b/src/dex/native/native-integration.test.ts
@@ -5,7 +5,7 @@ dotenv.config();
 process.env.API_KEY_NATIVE = process.env.API_KEY_NATIVE || 'test-native-key';
 
 import { DummyDexHelper } from '../../dex-helper';
-import { Network, SwapSide, CACHE_PREFIX } from '../../constants';
+import { Network, SwapSide } from '../../constants';
 import { Native } from './native';
 import { Tokens } from '../../../tests/constants-e2e';
 import { BI_POWS } from '../../bigint-constants';
@@ -19,8 +19,6 @@ describe('Native Integration (unit cache based)', () => {
 
   const weth = tokens.WETH;
   const usdc = tokens.USDC;
-
-  const orderbookCacheKey = `${CACHE_PREFIX}_${network}_${dexKey}_orderbook`;
 
   beforeAll(async () => {
     const mockOrderbook = [
@@ -39,10 +37,12 @@ describe('Native Integration (unit cache based)', () => {
       },
     ];
 
-    await dexHelper.cache.rawset(
-      orderbookCacheKey,
-      JSON.stringify(mockOrderbook),
+    await dexHelper.cache.setex(
+      dexKey,
+      network,
+      'orderbook',
       60,
+      JSON.stringify(mockOrderbook),
     );
   });
 
@@ -137,15 +137,13 @@ describe('Native Integration (unit cache based)', () => {
 
     // Mock WETH price at $3200 USD per token
     const wethPriceUsd = 3200;
-    dexHelper.getTokenUSDPrice = async (token, amount) => {
-      if (token.address.toLowerCase() === weth.address.toLowerCase()) {
-        // Return USD value: for 1 WETH (10^18 wei), return $3200
-        const normalizedAmount = Number(amount / BigInt(10 ** token.decimals));
-        return normalizedAmount * wethPriceUsd;
-      }
-      // Default behavior for other tokens
-      return Number(amount / BigInt(10 ** token.decimals));
-    };
+    dexHelper.getUsdTokenAmounts = async tokenAmounts =>
+      tokenAmounts.map(([token, amount]) => {
+        const isWeth = token.toLowerCase() === weth.address.toLowerCase();
+        const decimals = isWeth ? weth.decimals : usdc.decimals;
+        const usdPrice = isWeth ? wethPriceUsd : 1;
+        return Number(amount! / BigInt(10 ** decimals)) * usdPrice;
+      });
 
     const pools = await native.getTopPoolsForToken(weth.address, 10);
 

--- a/src/dex/native/native.ts
+++ b/src/dex/native/native.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 import { assert } from 'ts-essentials';
 import { BN_0, BN_1, getBigNumberPow } from '../../bignumber-constants';
-import { Network, SwapSide } from '../../constants';
+import { Network, NULL_ADDRESS, SwapSide } from '../../constants';
 import { IDexHelper } from '../../dex-helper/idex-helper';
 import { IDex } from '../../dex/idex';
 import {
@@ -40,6 +40,7 @@ import {
   NATIVE_GAS_COST,
   NATIVE_ORDERBOOK_CACHE_TTL_S,
   NATIVE_ORDERBOOK_POLLING_INTERVAL_MS,
+  NATIVE_TRADE_RFQT_SELECTOR,
 } from './constants';
 import { BytesLike, formatUnits, parseUnits } from 'ethers/lib/utils';
 import { uint8ToNumber } from '../../lib/decoders';
@@ -237,8 +238,10 @@ export class Native
       CALLDATA_GAS_COST.AMOUNT * 3 + // sellerTokenAmount, buyerTokenAmount, amountOutMinimum
       CALLDATA_GAS_COST.TIMESTAMP + // deadlineTimestamp
       CALLDATA_GAS_COST.AMOUNT * 5 + // nonce + confidenceT,N,E,M
+      CALLDATA_GAS_COST.ADDRESS * 2 + // expectedPayer, expectedOrigin
+      CALLDATA_GAS_COST.AMOUNT * 4 + // confidenceP,O,R,D
       CALLDATA_GAS_COST.UUID + // quoteId
-      CALLDATA_GAS_COST.BOOL + // multiHop
+      CALLDATA_GAS_COST.BOOL * 2 + // multiHop, skipPAMM
       CALLDATA_GAS_COST.OFFSET_LARGE * 2 +
       CALLDATA_GAS_COST.LENGTH_SMALL +
       CALLDATA_GAS_COST.FULL_WORD * 3 + // signature
@@ -299,7 +302,16 @@ export class Native
       expiry_time: NATIVE_FIRM_QUOTE_EXPIRY_S.toString(),
     };
 
-    if (options.userAddress) {
+    if (this.isNonZeroAddress(options.executionContractAddress)) {
+      firmQuoteParams.execution_payer =
+        options.executionContractAddress.toLowerCase();
+    }
+
+    if (this.isNonZeroAddress(options.txOrigin)) {
+      firmQuoteParams.tx_origin = options.txOrigin.toLowerCase();
+    }
+
+    if (this.isNonZeroAddress(options.userAddress)) {
       firmQuoteParams.beneficiary_address = options.userAddress.toLowerCase();
     }
 
@@ -423,8 +435,8 @@ export class Native
 
     let insertFromAmountPos;
 
-    // function selectof for tradeRFQT
-    if (selector === '0x0947c2d9') {
+    // function selector for tradeRFQT
+    if (selector === NATIVE_TRADE_RFQT_SELECTOR) {
       insertFromAmountPos = 36; // position of actualSellerAmount in calldata
     }
 
@@ -719,6 +731,10 @@ export class Native
       });
 
     return response.data;
+  }
+
+  private isNonZeroAddress(address?: Address): address is Address {
+    return !!address && address.toLowerCase() !== NULL_ADDRESS;
   }
 
   private normalizeTxRequest(txRequest: NativeTxRequest) {


### PR DESCRIPTION
## Summary

Upgrades Native RFQ firm quotes to Router v6.

- Set `/firm-quote` to `version=6` and update Native Router addresses on Ethereum, BSC, Arbitrum, and Base.
- Use the v6 `tradeRFQT` selector and account for its added fields in calldata gas estimation.
- Pass optional Native v6 identity context when available:
  - `execution_payer`: Augustus executor
  - `tx_origin`: submitting EOA
  - `beneficiary_address`: final Velora user
- Update Native unit-test fixtures and assertions for v6 calldata and firm-quote parameters.

Reference: [Native Router v6 Doc](https://nativefi.notion.site/external-Native-Router-Version-6-PropAMM-Add-on-3c16a18f090581a2a099d6377f70d6e8)

## Test plan

- [x] `pnpm checks`
- [x] `pnpm test src/dex/native/native-dex-param.test.ts src/dex/native/native-gas-estimation.test.ts src/dex/native/native-integration.test.ts --runInBand --forceExit`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live swap routing (new router contracts and API version) and firm-quote parameters; misconfiguration could break quotes or on-chain execution until validated in production.
> 
> **Overview**
> Upgrades the Native DEX integration from Router **v4** to **v6**: firm-quote requests use `version=6`, on-chain targets use new router addresses on Ethereum, BSC, Arbitrum, and Base, and `tradeRFQT` is recognized via selector `0x7083527c` (replacing the old selector).
> 
> **Firm-quote and execution behavior** now optionally sends Native v6 identity fields when addresses are non-null: `execution_payer` (Augustus executor), `tx_origin`, and `beneficiary_address`. Calldata gas estimation is expanded for v6 `tradeRFQT` layout (extra addresses, confidence words, and `skipPAMM`).
> 
> Tests are aligned with v6 (request params, selector constant, orderbook cache via `setex`, USD liquidity via `getUsdTokenAmounts`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08eb394e937893a65d42acb975aca8844ec8f3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->