### PR TITLE
fix: MaverickV2 pricing math correctness and quote performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paraswap/dex-lib",
-  "version": "5.1.15",
+  "version": "5.1.16",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "repository": "https://github.com/paraswap/paraswap-dex-lib",

--- a/src/dex/maverick-v2/maverick-math/maverick-basic-math.ts
+++ b/src/dex/maverick-v2/maverick-math/maverick-basic-math.ts
@@ -100,17 +100,7 @@ export class MaverickBasicMath {
   }
 
   static mulDivDown(x: bigint, y: bigint, denominator: bigint): bigint {
-    let z = x * y;
-
-    if (denominator === 0n) {
-      denominator = 1n;
-    }
-
-    if (denominator === 0n && !(y === 0n || x <= BI_MAX_UINT256 / y)) {
-      throw new Error('MATH: MUL_DIV_DOWN_OVERFLOW');
-    }
-
-    return z / denominator;
+    return (x * y) / (denominator === 0n ? 1n : denominator);
   }
 
   static mulDiv(x: bigint, y: bigint, denominator: bigint): bigint {

--- a/src/dex/maverick-v2/maverick-math/maverick-pool-math.ts
+++ b/src/dex/maverick-v2/maverick-math/maverick-pool-math.ts
@@ -25,12 +25,11 @@ export class MaverickPoolMath {
   tokenBScale: bigint;
   timestamp: bigint;
 
+  private sqrtPriceCache = new Map<bigint, [bigint, bigint]>();
+
   constructor(
-    private feeAIn: bigint,
-    private feeBIn: bigint,
     private lookback: bigint,
     private tickSpacing: bigint,
-    private protocolFeeRatioD3: bigint,
     private activeTick: bigint,
     private tokenADecimals: bigint,
     private tokenBDecimals: bigint,
@@ -42,6 +41,9 @@ export class MaverickPoolMath {
       lastTwaD8: 0n,
       lastLogPriceD8: 0n,
       lastTimestamp: 0n,
+      feeAIn: 0n,
+      feeBIn: 0n,
+      protocolFeeRatioD3: 0n,
       binCounter: 0n,
       bins: {},
       ticks: {},
@@ -372,7 +374,7 @@ export class MaverickPoolMath {
       startingTickState.totalSupply,
       firstBin.tickBalance,
     );
-    startingTickState.binIdsByTick[moveData.kind.toString()] = 0n;
+    delete startingTickState.binIdsByTick[moveData.kind.toString()];
     if (this.state.ticks[firstBin.tick.toString()].totalSupply === 0n) {
       delete this.state.ticks[firstBin.tick.toString()];
     }
@@ -595,6 +597,17 @@ export class MaverickPoolMath {
     );
   }
 
+  // Tick sqrt prices depend only on (tickSpacing, tick), so they are memoised
+  // per pool: computing them costs ~20 wide multiplications and a division.
+  tickSqrtPrices(tick: bigint): [bigint, bigint] {
+    let prices = this.sqrtPriceCache.get(tick);
+    if (!prices) {
+      prices = MaverickTickMath.tickSqrtPrices(this.tickSpacing, tick);
+      this.sqrtPriceCache.set(tick, prices);
+    }
+    return prices;
+  }
+
   tickSqrtPriceAndLiquidity(tick: bigint): [bigint, bigint, bigint, TickData] {
     let tickState = this.state.ticks[tick.toString()];
     let output: TickData = {
@@ -603,8 +616,7 @@ export class MaverickPoolMath {
       currentLiquidity: 0n,
     };
 
-    let [sqrtLowerTickPrice, sqrtUpperTickPrice] =
-      MaverickTickMath.tickSqrtPrices(this.tickSpacing, tick);
+    let [sqrtLowerTickPrice, sqrtUpperTickPrice] = this.tickSqrtPrices(tick);
 
     let sqrtPrice;
     [sqrtPrice, output.currentLiquidity] =
@@ -655,7 +667,7 @@ export class MaverickPoolMath {
           delta.excess,
           delta.tokenAIn,
           this.fee(delta.tokenAIn),
-          this.protocolFeeRatioD3,
+          this.state.protocolFeeRatioD3,
         )
       : MaverickSwapMath.computeSwapExactIn(
           delta.sqrtPrice,
@@ -663,7 +675,7 @@ export class MaverickPoolMath {
           delta.excess,
           delta.tokenAIn,
           this.fee(delta.tokenAIn),
-          this.protocolFeeRatioD3,
+          this.state.protocolFeeRatioD3,
         );
 
     if (newDelta.excess === 0n) {
@@ -686,7 +698,7 @@ export class MaverickPoolMath {
   }
 
   fee(tokenAIn: boolean): bigint {
-    return tokenAIn ? this.feeAIn : this.feeBIn;
+    return tokenAIn ? this.state.feeAIn : this.state.feeBIn;
   }
 
   allocateSwapValuesToTick(delta: Delta, tokenAIn: boolean, tick: bigint) {

--- a/src/dex/maverick-v2/maverick-math/maverick-tick-math.ts
+++ b/src/dex/maverick-v2/maverick-math/maverick-tick-math.ts
@@ -1,5 +1,4 @@
 import { BI_MAX_UINT256, BI_POWS } from '../../../bigint-constants';
-import { _require } from '../../../utils';
 import { MaverickBasicMath } from './maverick-basic-math';
 
 const MAX_TICK = 460540;
@@ -71,19 +70,23 @@ export class MaverickTickMath {
       reserveB <<= precisionBump;
     }
 
-    let diff;
-    let b =
-      MaverickBasicMath.divDown(reserveA, sqrtUpperTickPrice) +
-      MaverickBasicMath.mulDown(reserveB, sqrtLowerTickPrice);
-    diff = sqrtUpperTickPrice - sqrtLowerTickPrice;
+    const diff = sqrtUpperTickPrice - sqrtLowerTickPrice;
 
-    if (reserveA === 0n || reserveB === 0n)
+    if (reserveB === 0n)
+      return MaverickBasicMath.divDown(reserveA, diff) >> precisionBump;
+    if (reserveA === 0n)
       return (
-        MaverickBasicMath.mulDivDown(b, sqrtUpperTickPrice, diff) >>
-        precisionBump
+        MaverickBasicMath.mulDivDown(
+          MaverickBasicMath.mulDown(reserveB, sqrtLowerTickPrice),
+          sqrtUpperTickPrice,
+          diff,
+        ) >> precisionBump
       );
 
-    b >>= 1n;
+    const b =
+      (MaverickBasicMath.divDown(reserveA, sqrtUpperTickPrice) +
+        MaverickBasicMath.mulDown(reserveB, sqrtLowerTickPrice)) >>
+      1n;
 
     return (
       MaverickBasicMath.mulDiv(

--- a/src/dex/maverick-v2/maverick-v2-e2e.test.ts
+++ b/src/dex/maverick-v2/maverick-v2-e2e.test.ts
@@ -11,7 +11,11 @@ import {
 import { Network, ContractMethod, SwapSide } from '../../constants';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { generateConfig } from '../../config';
-import { ContractMethodV6 } from '@paraswap/sdk';
+import { DummyDexHelper } from '../../dex-helper/index';
+import { Token } from '../../types';
+import { MaverickV2 } from './maverick-v2';
+
+jest.setTimeout(120 * 1000);
 
 /*
   README
@@ -52,6 +56,58 @@ import { ContractMethodV6 } from '@paraswap/sdk';
   (This comment should be removed from the final implementation)
 */
 
+// One initialised dex per network, shared by every test case on that network
+const dexByNetwork = new Map<
+  Network,
+  Promise<{ dex: MaverickV2; blockNumber: number }>
+>();
+
+function getInitializedDex(network: Network, dexKey: string) {
+  let initialized = dexByNetwork.get(network);
+  if (!initialized) {
+    initialized = (async () => {
+      const dexHelper = new DummyDexHelper(network);
+      const dex = new MaverickV2(network, dexKey, dexHelper);
+      const blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+      await dex.initializePricing(blockNumber);
+      return { dex, blockNumber };
+    })();
+    dexByNetwork.set(network, initialized);
+  }
+  return initialized;
+}
+
+// The local SDK prices the first pool of the pair, and pools that can't fill
+// the amount price it as 0, so pin the pool with the best full fill
+async function bestPoolIdentifiers(
+  dex: MaverickV2,
+  blockNumber: number,
+  srcToken: Token,
+  destToken: Token,
+  amount: string,
+  side: SwapSide,
+): Promise<{ [dexKey: string]: string[] }> {
+  const poolPrices = await dex.getPricesVolume(
+    srcToken,
+    destToken,
+    [0n, BigInt(amount)],
+    side,
+    blockNumber,
+  );
+  const filled = (poolPrices || []).filter(p => p.prices[1] !== 0n);
+  expect(filled.length).toBeGreaterThan(0);
+
+  filled.sort((a, b) => {
+    const aBetter =
+      side === SwapSide.SELL
+        ? a.prices[1] > b.prices[1]
+        : a.prices[1] < b.prices[1];
+    return aBetter ? -1 : 1;
+  });
+
+  return { [dex.dexKey]: filled[0].poolIdentifiers! };
+}
+
 function testForNetwork(
   network: Network,
   dexKey: string,
@@ -75,34 +131,63 @@ function testForNetwork(
   ]);
 
   describe(`${network}`, () => {
+    let dex: MaverickV2;
+    let blockNumber: number;
+
+    beforeAll(async () => {
+      ({ dex, blockNumber } = await getInitializedDex(network, dexKey));
+    });
+
     sideToContractMethods.forEach((contractMethods, side) =>
       describe(`${side}`, () => {
         contractMethods.forEach((contractMethod: ContractMethod) => {
           describe(`${contractMethod}`, () => {
             it(`${tokenASymbol} -> ${tokenBSymbol}`, async () => {
+              const amount =
+                side === SwapSide.SELL ? tokenAAmount : tokenBAmount;
+              const poolIdentifiers = await bestPoolIdentifiers(
+                dex,
+                blockNumber,
+                tokens[tokenASymbol],
+                tokens[tokenBSymbol],
+                amount,
+                side,
+              );
               await testE2E(
                 tokens[tokenASymbol],
                 tokens[tokenBSymbol],
                 holders[tokenASymbol],
-                side === SwapSide.SELL ? tokenAAmount : tokenBAmount,
+                amount,
                 side,
                 dexKey,
                 contractMethod,
                 network,
                 provider,
+                poolIdentifiers,
               );
             });
             it(`${tokenBSymbol} -> ${tokenASymbol}`, async () => {
+              const amount =
+                side === SwapSide.SELL ? tokenBAmount : tokenAAmount;
+              const poolIdentifiers = await bestPoolIdentifiers(
+                dex,
+                blockNumber,
+                tokens[tokenBSymbol],
+                tokens[tokenASymbol],
+                amount,
+                side,
+              );
               await testE2E(
                 tokens[tokenBSymbol],
                 tokens[tokenASymbol],
                 holders[tokenBSymbol],
-                side === SwapSide.SELL ? tokenBAmount : tokenAAmount,
+                amount,
                 side,
                 dexKey,
                 contractMethod,
                 network,
                 provider,
+                poolIdentifiers,
               );
             });
           });
@@ -116,19 +201,21 @@ describe('MaverickV2 E2E', () => {
   const dexKey = 'MaverickV2';
 
   const testCases = [
+    // The local SDK prices on the state at init time, so prefer pairs that
+    // aren't arbitraged every block
     {
       network: Network.BASE,
-      tokenASymbol: 'USDC',
-      tokenBSymbol: 'ETH',
-      tokenAAmount: '1000000000',
-      tokenBAmount: '1000000000000000000',
+      tokenASymbol: 'DAI',
+      tokenBSymbol: 'USDC',
+      tokenAAmount: '100000000000000000000',
+      tokenBAmount: '100000000',
     },
     {
       network: Network.ARBITRUM,
       tokenASymbol: 'USDC',
       tokenBSymbol: 'ETH',
       tokenAAmount: '1000000',
-      tokenBAmount: '1000000000000000000',
+      tokenBAmount: '100000000000000000',
     },
     {
       network: Network.BSC,
@@ -139,16 +226,16 @@ describe('MaverickV2 E2E', () => {
     },
     {
       network: Network.MAINNET,
-      tokenASymbol: 'GHO',
-      tokenBSymbol: 'USDC',
-      tokenAAmount: '1000000000000000000000',
-      tokenBAmount: '100000000000',
+      tokenASymbol: 'USDC',
+      tokenBSymbol: 'USDS',
+      tokenAAmount: '1000000000',
+      tokenBAmount: '1000000000000000000000',
     },
     {
       network: Network.MAINNET,
       tokenASymbol: 'ETH',
       tokenBSymbol: 'USDC',
-      tokenAAmount: '1000000000000000000',
+      tokenAAmount: '1000000000000000',
       tokenBAmount: '1000000',
     },
   ];

--- a/src/dex/maverick-v2/maverick-v2-events.test.ts
+++ b/src/dex/maverick-v2/maverick-v2-events.test.ts
@@ -80,7 +80,6 @@ describe('MaverickV2 EventPool Mainnet', function () {
             pool.feeA,
             pool.feeB,
             pool.tickSpacing,
-            pool.protocolFee,
             pool.lookback,
             pool.activeTick,
             poolAddress,

--- a/src/dex/maverick-v2/maverick-v2-integration.test.ts
+++ b/src/dex/maverick-v2/maverick-v2-integration.test.ts
@@ -59,8 +59,8 @@ function calculateSwap(
         pool.data.tokenA.toLowerCase() === srcToken.toLowerCase(),
         side === SwapSide.BUY,
         pool.data.tokenA.toLowerCase() === srcToken.toLowerCase()
-          ? 100n
-          : -100n,
+          ? BigInt(pool.data.activeTick) + 100n
+          : BigInt(pool.data.activeTick) - 100n,
       )
       .call({}, blockNumber, (err: any, result: any) => {
         if (err) {
@@ -105,13 +105,15 @@ async function checkOnChainPricing(
 
       const results = await Promise.all(calls);
 
+      // A BUY that can't deliver the full amount is priced as 0
       const expectedPrices = [0n].concat(
-        results.map((result: any) => {
-          if (!result) return BigInt(0);
+        results.map((result: any, i: number) => {
+          if (!result) return 0n;
+          const amountIn = BigInt(result.amountIn);
+          const amountOut = BigInt(result.amountOut);
 
-          return BigInt(
-            side === SwapSide.SELL ? result.amountOut : result.amountIn,
-          );
+          if (side === SwapSide.SELL) return amountOut;
+          return amountOut === amounts[i + 1] ? amountIn : 0n;
         }),
       );
 
@@ -159,10 +161,16 @@ async function testPricingOnNetwork(
   );
 
   expect(poolPrices).not.toBeNull();
+  // Thin pools return 0 once an amount can't be fully filled; the
+  // monotonic price check only makes sense for pools that fill every amount
+  const fullyFilledPools = poolPrices!.filter(pool =>
+    pool.prices.slice(1).every(price => price !== 0n),
+  );
+  expect(fullyFilledPools.length).toBeGreaterThan(0);
   if (maverickV2.hasConstantPriceLargeAmounts) {
-    checkConstantPoolPrices(poolPrices!, amounts, dexKey);
+    checkConstantPoolPrices(fullyFilledPools, amounts, dexKey);
   } else {
-    checkPoolPrices(poolPrices!, amounts, side, dexKey);
+    checkPoolPrices(fullyFilledPools, amounts, side, dexKey);
   }
 
   // Check if onchain pricing equals to calculated ones
@@ -176,14 +184,16 @@ async function testPricingOnNetwork(
   );
 }
 
+jest.setTimeout(120 * 1000);
+
 const testCases = [
-  { network: Network.MAINNET, srcTokenSymbol: 'GHO', destTokenSymbol: 'USDC' },
+  { network: Network.MAINNET, srcTokenSymbol: 'USDC', destTokenSymbol: 'USDS' },
   {
     network: Network.ARBITRUM,
     srcTokenSymbol: 'USDT',
     destTokenSymbol: 'USDC',
   },
-  { network: Network.BASE, srcTokenSymbol: 'ETH', destTokenSymbol: 'wstETH' },
+  { network: Network.BASE, srcTokenSymbol: 'USDC', destTokenSymbol: 'USDS' },
   // {network: Network.BSC, srcTokenSymbol: "USDC", destTokenSymbol: "USDT"},
 ];
 describe('MaverickV2', function () {

--- a/src/dex/maverick-v2/maverick-v2-pool.ts
+++ b/src/dex/maverick-v2/maverick-v2-pool.ts
@@ -7,13 +7,13 @@ import { IDexHelper } from '../../dex-helper/idex-helper';
 import { PoolState } from './types';
 import MaverickV2PoolABI from '../../abi/maverick-v2/MaverickV2Pool.json';
 import MaverickV2PoolLensABI from '../../abi/maverick-v2/MaverickV2PoolLens.json';
-import { AbiItem } from 'web3-utils';
-import { Contract } from 'web3-eth-contract';
 import { MaverickPoolMath } from './maverick-math/maverick-pool-math';
 import { MultiResult } from '../../lib/multi-wrapper';
 import { BytesLike } from 'ethers';
 import { extractSuccessAndValue } from '../../lib/decoders';
 import { getTopicLogDecoder } from '../../lib/topic-log-decoder';
+
+const BINS_PER_LENS_CALL = 5000n;
 
 export const decodeMaverickFullState = (
   result: MultiResult<BytesLike> | BytesLike,
@@ -75,7 +75,6 @@ export class MaverickV2EventPool extends StatefulEventSubscriber<PoolState> {
     ) => DeepReadonly<PoolState> | null;
   } = {};
 
-  poolContract: Contract;
   logDecoder: (log: Log) => any;
 
   addressesSubscribed: string[];
@@ -92,7 +91,6 @@ export class MaverickV2EventPool extends StatefulEventSubscriber<PoolState> {
     public feeAIn: bigint,
     public feeBIn: bigint,
     public tickSpacing: bigint,
-    public protocolFeeRatio: bigint,
     public lookback: bigint,
     public activeTick: bigint,
     public address: Address,
@@ -116,21 +114,17 @@ export class MaverickV2EventPool extends StatefulEventSubscriber<PoolState> {
     this.handlers['PoolRemoveLiquidity'] =
       this.handleRemoveLiquidityEvent.bind(this);
     this.handlers['PoolSwap'] = this.handleSwapEvent.bind(this);
+    this.handlers['PoolSetVariableFee'] =
+      this.handleSetVariableFeeEvent.bind(this);
+    this.handlers['PoolSetProtocolFeeRatio'] =
+      this.handleSetProtocolFeeRatioEvent.bind(this);
 
     this.poolMath = new MaverickPoolMath(
-      BigInt(feeAIn),
-      BigInt(feeBIn),
       BigInt(lookback),
       BigInt(tickSpacing),
-      BigInt(protocolFeeRatio),
       BigInt(activeTick),
       BigInt(tokenA.decimals),
       BigInt(tokenB.decimals),
-    );
-
-    this.poolContract = new this.dexHelper.web3Provider.eth.Contract(
-      MaverickV2PoolABI as AbiItem[],
-      this.address,
     );
   }
 
@@ -170,88 +164,166 @@ export class MaverickV2EventPool extends StatefulEventSubscriber<PoolState> {
    * @returns state of the event subscriber at blocknumber
    */
 
+  private lensCall(binStart: bigint) {
+    return {
+      target: this.poolLensAddress,
+      callData: this.maverickV2LensIface.encodeFunctionData(
+        'getFullPoolState',
+        [this.address, binStart, binStart + BINS_PER_LENS_CALL - 1n],
+      ),
+      decodeFunction: (data: MultiResult<BytesLike> | BytesLike) => {
+        const [, returnData] = extractSuccessAndValue(data);
+        return returnData === '0x' ? null : decodeMaverickFullState(returnData);
+      },
+    };
+  }
+
   async generateState(blockNumber: number): Promise<DeepReadonly<PoolState>> {
-    try {
-      const poolContractState = await this.poolContract.methods
-        .getState()
-        .call({}, blockNumber);
+    // Pool params and the first page of bins in one round-trip; only pools
+    // with more than BINS_PER_LENS_CALL bins need a second one
+    const [stateResult, feeAInResult, feeBInResult, firstLensPage] =
+      await this.dexHelper.multiWrapper.tryAggregate<any>(
+        false,
+        [
+          {
+            target: this.address,
+            callData: this.maverickV2Iface.encodeFunctionData('getState'),
+            decodeFunction: (data: MultiResult<BytesLike> | BytesLike) => {
+              const [, returnData] = extractSuccessAndValue(data);
+              return returnData === '0x'
+                ? null
+                : this.maverickV2Iface.decodeFunctionResult(
+                    'getState',
+                    returnData,
+                  )[0];
+            },
+          },
+          ...[true, false].map(tokenAIn => ({
+            target: this.address,
+            callData: this.maverickV2Iface.encodeFunctionData('fee', [
+              tokenAIn,
+            ]),
+            decodeFunction: (data: MultiResult<BytesLike> | BytesLike) => {
+              const [, returnData] = extractSuccessAndValue(data);
+              return returnData === '0x'
+                ? null
+                : BigInt(
+                    this.maverickV2Iface
+                      .decodeFunctionResult('fee', returnData)[0]
+                      .toString(),
+                  );
+            },
+          })),
+          this.lensCall(0n),
+        ],
+        blockNumber,
+        undefined,
+        false,
+      );
 
-      const poolState: PoolState = {
-        activeTick: BigInt(poolContractState.activeTick),
-        binCounter: BigInt(poolContractState.binCounter),
-        reserveA: BigInt(poolContractState.reserveA),
-        reserveB: BigInt(poolContractState.reserveB),
-        lastTwaD8: BigInt(poolContractState.lastTwaD8),
-        lastLogPriceD8: BigInt(poolContractState.lastLogPriceD8),
-        lastTimestamp: BigInt(poolContractState.lastTimestamp),
-        bins: {},
-        ticks: {},
-      };
-
-      const calls = [];
-
-      for (let i = 0n; i < poolState.binCounter / 5000n + 1n; i++) {
-        calls.push({
-          target: this.poolLensAddress,
-          callData: this.maverickV2LensIface.encodeFunctionData(
-            'getFullPoolState',
-            [this.address, i * 5000n, (i + 1n) * 5000n],
-          ),
-          decodeFunction: (data: any) => data.toString(),
-        });
-      }
-
-      const poolLensStates = await this.dexHelper.multiWrapper
-        .aggregate<string>(calls, blockNumber)
-        .then(data => {
-          return data.map(item => decodeMaverickFullState(item));
-        });
-
-      poolLensStates.forEach(poolLensState => {
-        poolLensState.binStateMapping.forEach((bin: any, i: number) => {
-          if (i === 0) return;
-
-          const tick = poolLensState.tickStateMapping[i];
-
-          poolState.bins[i.toString()] = {
-            mergeBinBalance: BigInt(bin.mergeBinBalance),
-            mergeId: BigInt(bin.mergeId),
-            totalSupply: BigInt(bin.totalSupply),
-            kind: BigInt(bin.kind),
-            tick: BigInt(bin.tick),
-            tickBalance: BigInt(bin.tickBalance),
-          };
-
-          poolState.ticks[bin.tick.toString()] = {
-            reserveA: BigInt(tick.reserveA),
-            reserveB: BigInt(tick.reserveB),
-            totalSupply: BigInt(tick.totalSupply),
-            binIdsByTick: {},
-          };
-
-          tick.binIdsByTick.forEach((id: any, i: number) => {
-            if (id != 0n) {
-              poolState.ticks[bin.tick.toString()].binIdsByTick[i.toString()] =
-                BigInt(id);
-            }
-          });
-        });
-      });
-
-      return poolState;
-    } catch {
+    // The pool is not deployed yet at this block (call fails or returns no
+    // data): empty state with the creation parameters, so that logs from the
+    // creation block replay
+    if (!stateResult.success || stateResult.returnData == null) {
       return {
-        activeTick: BigInt(0),
-        binCounter: BigInt(0),
-        reserveA: BigInt(0),
-        reserveB: BigInt(0),
-        lastTwaD8: BigInt(0),
-        lastLogPriceD8: BigInt(0),
-        lastTimestamp: BigInt(0),
+        activeTick: BigInt(this.activeTick),
+        binCounter: 0n,
+        reserveA: 0n,
+        reserveB: 0n,
+        lastTwaD8: 0n,
+        lastLogPriceD8: 0n,
+        lastTimestamp: 0n,
+        feeAIn: BigInt(this.feeAIn),
+        feeBIn: BigInt(this.feeBIn),
+        protocolFeeRatioD3: 0n,
         bins: {},
         ticks: {},
       };
     }
+
+    const poolContractState = stateResult.returnData;
+    const poolState: PoolState = {
+      activeTick: BigInt(poolContractState.activeTick),
+      binCounter: BigInt(poolContractState.binCounter),
+      reserveA: BigInt(poolContractState.reserveA.toString()),
+      reserveB: BigInt(poolContractState.reserveB.toString()),
+      lastTwaD8: BigInt(poolContractState.lastTwaD8.toString()),
+      lastLogPriceD8: BigInt(poolContractState.lastLogPriceD8.toString()),
+      lastTimestamp: BigInt(poolContractState.lastTimestamp),
+      protocolFeeRatioD3: BigInt(poolContractState.protocolFeeRatioD3),
+      feeAIn: feeAInResult.returnData,
+      feeBIn: feeBInResult.returnData,
+      bins: {},
+      ticks: {},
+    };
+
+    const poolLensStates = [firstLensPage.returnData];
+
+    const calls = [];
+    for (
+      let binStart = BINS_PER_LENS_CALL;
+      binStart <= poolState.binCounter;
+      binStart += BINS_PER_LENS_CALL
+    ) {
+      calls.push(this.lensCall(binStart));
+    }
+    if (calls.length) {
+      poolLensStates.push(
+        ...(await this.dexHelper.multiWrapper.aggregate<any>(
+          calls,
+          blockNumber,
+        )),
+      );
+    }
+
+    // The lens returns arrays indexed relative to binStart, not by bin id
+    poolLensStates.forEach((poolLensState, page) => {
+      const binStart = BigInt(page) * BINS_PER_LENS_CALL;
+
+      poolLensState.binStateMapping.forEach((bin: any, i: number) => {
+        const binId = binStart + BigInt(i);
+        if (binId === 0n) return;
+
+        const tick = poolLensState.tickStateMapping[i];
+        const tickKey = bin.tick.toString();
+
+        poolState.bins[binId.toString()] = {
+          mergeBinBalance: BigInt(bin.mergeBinBalance),
+          mergeId: BigInt(bin.mergeId),
+          totalSupply: BigInt(bin.totalSupply),
+          kind: BigInt(bin.kind),
+          tick: BigInt(bin.tick),
+          tickBalance: BigInt(bin.tickBalance),
+        };
+
+        poolState.ticks[tickKey] = {
+          reserveA: BigInt(tick.reserveA),
+          reserveB: BigInt(tick.reserveB),
+          totalSupply: BigInt(tick.totalSupply),
+          binIdsByTick: {},
+        };
+
+        tick.binIdsByTick.forEach((id: any, kind: number) => {
+          const tickBinId = BigInt(id.toString());
+          if (tickBinId !== 0n) {
+            poolState.ticks[tickKey].binIdsByTick[kind.toString()] = tickBinId;
+          }
+        });
+      });
+    });
+
+    return poolState;
+  }
+
+  handleSetVariableFeeEvent(event: any, state: PoolState) {
+    state.feeAIn = BigInt(event.args.newFeeAIn.toString());
+    state.feeBIn = BigInt(event.args.newFeeBIn.toString());
+    return state;
+  }
+
+  handleSetProtocolFeeRatioEvent(event: any, state: PoolState) {
+    state.protocolFeeRatioD3 = BigInt(event.args.protocolFeeRatioD3.toString());
+    return state;
   }
 
   handleRemoveLiquidityEvent(
@@ -309,9 +381,13 @@ export class MaverickV2EventPool extends StatefulEventSubscriber<PoolState> {
   ): [bigint, bigint] {
     try {
       const s = this.state!;
+      // Copy-on-write overlay: estimateSwap only reads ticks by key and
+      // replaces the ones it touches, so a prototype-chained object avoids
+      // copying the whole ticks map on every quote. The estimate path must
+      // never iterate or delete ticks for this to stay correct.
       const tempState: PoolState = {
         ...s,
-        ticks: { ...s.ticks },
+        ticks: Object.create(s.ticks),
       };
 
       const preActiveTick = tempState.activeTick;

--- a/src/dex/maverick-v2/maverick-v2.ts
+++ b/src/dex/maverick-v2/maverick-v2.ts
@@ -84,15 +84,21 @@ export class MaverickV2 extends SimpleExchange implements IDex<MaverickV2Data> {
           BigInt(pool.fee * 1e18),
           BigInt(pool.feeB * 1e18),
           BigInt(pool.tickSpacing),
-          BigInt(0),
           BigInt(pool.lookback),
           BigInt(pool.lowerTick),
           pool.id,
           this.config.poolLensAddress,
         );
 
-        await eventPool.initialize(blockNumber);
-        this.pools[eventPool.address] = eventPool;
+        try {
+          await eventPool.initialize(blockNumber);
+          this.pools[eventPool.address] = eventPool;
+        } catch (e) {
+          this.logger.error(
+            `${this.dexKey}: failed to initialize pool ${pool.id}, skipping`,
+            e,
+          );
+        }
       }),
     );
   }

--- a/src/dex/maverick-v2/scripts/compare-onchain-quotes.ts
+++ b/src/dex/maverick-v2/scripts/compare-onchain-quotes.ts
@@ -1,0 +1,249 @@
+/* eslint-disable no-console */
+/*
+
+Compares MaverickV2 local pricing with on-chain results at one block, for
+every pool the dex initializes on the given network:
+  - tick sqrt price / liquidity vs PoolLens.getTickSqrtPriceAndL
+  - estimateSwap (amountIn, amountOut) vs Quoter.calculateSwap, both
+    directions, exact-in and exact-out, using the same tickLimit as pricing
+
+Usage: npx ts-node src/dex/maverick-v2/scripts/compare-onchain-quotes.ts [network=1]
+
+*/
+import * as dotenv from 'dotenv';
+dotenv.config();
+import { Interface } from '@ethersproject/abi';
+import { BytesLike } from 'ethers';
+import { DummyDexHelper } from '../../../dex-helper';
+import { MaverickV2 } from '../maverick-v2';
+import { MaverickV2Config } from '../config';
+import { MaverickTickMath } from '../maverick-math/maverick-tick-math';
+import { PoolState } from '../types';
+import { extractSuccessAndValue } from '../../../lib/decoders';
+import { MultiResult } from '../../../lib/multi-wrapper';
+import QuoterABI from '../../../abi/maverick-v2/MaverickV2Quoter.json';
+import LensABI from '../../../abi/maverick-v2/MaverickV2PoolLens.json';
+
+const network = Number(process.argv[2] || 1);
+const dexKey = 'MaverickV2';
+const quoterIface = new Interface(QuoterABI);
+const lensIface = new Interface(LensABI);
+const MAX_UINT128 = (1n << 128n) - 1n;
+
+const AMOUNT_MULTIPLIERS: [bigint, bigint][] = [
+  [1n, 1000000n],
+  [1n, 1000n],
+  [1n, 7n],
+  [1n, 1n],
+  [3n, 1n],
+  [17n, 1n],
+  [123n, 1n],
+  [1000n, 1n],
+  [12345n, 1n],
+  [100000n, 1n],
+];
+const RESERVE_FRACTIONS: [bigint, bigint][] = [
+  [1n, 10n],
+  [1n, 2n],
+  [9n, 10n],
+  [999n, 1000n],
+];
+
+type Pair = [bigint, bigint] | null;
+
+const decodePair =
+  (iface: Interface, fn: string, keys: [string, string]) =>
+  (result: MultiResult<BytesLike> | BytesLike): Pair => {
+    const [success, data] = extractSuccessAndValue(result);
+    if (!success || data === '0x') return null;
+    const decoded = iface.decodeFunctionResult(fn, data);
+    return [
+      BigInt(decoded[keys[0]].toString()),
+      BigInt(decoded[keys[1]].toString()),
+    ];
+  };
+
+const decodeQuote = decodePair(quoterIface, 'calculateSwap', [
+  'amountIn',
+  'amountOut',
+]);
+const decodeTick = decodePair(lensIface, 'getTickSqrtPriceAndL', [
+  'sqrtPrice',
+  'liquidity',
+]);
+
+(async () => {
+  const dexHelper = new DummyDexHelper(network);
+  const dex = new MaverickV2(network, dexKey, dexHelper);
+  const blockNumber = await dexHelper.web3Provider.eth.getBlockNumber();
+  await dex.initializePricing(blockNumber);
+  const { quoterAddress, poolLensAddress } = MaverickV2Config[dexKey][network];
+
+  const pools = Object.values(dex.pools).filter(p => p.getState(blockNumber));
+  console.log(`network=${network} block=${blockNumber} pools=${pools.length}`);
+
+  // ticks
+  const tickCalls = [];
+  const tickExpected: { pool: string; tick: bigint; local: Pair }[] = [];
+  for (const pool of pools) {
+    const state = pool.getState(blockNumber) as PoolState;
+    for (const [tickKey, tick] of Object.entries(state.ticks)) {
+      const [lower, upper] = MaverickTickMath.tickSqrtPrices(
+        pool.tickSpacing,
+        BigInt(tickKey),
+      );
+      tickExpected.push({
+        pool: pool.address,
+        tick: BigInt(tickKey),
+        local: MaverickTickMath.getTickSqrtPriceAndL(
+          tick.reserveA,
+          tick.reserveB,
+          lower,
+          upper,
+        ),
+      });
+      tickCalls.push({
+        target: poolLensAddress,
+        callData: lensIface.encodeFunctionData('getTickSqrtPriceAndL', [
+          pool.address,
+          tickKey,
+        ]),
+        decodeFunction: decodeTick,
+      });
+    }
+  }
+  const tickResults = await dexHelper.multiWrapper.tryAggregate<Pair>(
+    false,
+    tickCalls,
+    blockNumber,
+    200,
+    false,
+  );
+  let tickMismatches = 0;
+  tickResults.forEach(({ returnData: onchain }, i) => {
+    const { pool, tick, local } = tickExpected[i];
+    if (!onchain || !local) return;
+    if (onchain[0] !== local[0] || onchain[1] !== local[1]) {
+      tickMismatches++;
+      console.log(
+        `TICK MISMATCH pool=${pool} tick=${tick} local=[${local}] onchain=[${onchain}]`,
+      );
+    }
+  });
+
+  // swaps
+  type Case = {
+    pool: string;
+    label: string;
+    tokenAIn: boolean;
+    exactOutput: boolean;
+    amount: bigint;
+    local: Pair | string;
+  };
+  const cases: Case[] = [];
+  const quoteCalls = [];
+  for (const pool of pools) {
+    const state = pool.getState(blockNumber) as PoolState;
+    for (const tokenAIn of [true, false]) {
+      for (const exactOutput of [false, true]) {
+        const inToken = tokenAIn ? pool.tokenA : pool.tokenB;
+        const outToken = tokenAIn ? pool.tokenB : pool.tokenA;
+        const unit = 10n ** BigInt((exactOutput ? outToken : inToken).decimals);
+        const outReserve = tokenAIn ? state.reserveB : state.reserveA;
+        const amounts = new Set<bigint>();
+        AMOUNT_MULTIPLIERS.forEach(([n, d]) => amounts.add((unit * n) / d));
+        RESERVE_FRACTIONS.forEach(([n, d]) =>
+          amounts.add((outReserve * n) / d),
+        );
+        const tickLimit = tokenAIn
+          ? state.activeTick + 100n
+          : state.activeTick - 100n;
+
+        for (const amount of amounts) {
+          if (amount === 0n || amount > MAX_UINT128) continue;
+          let local: Pair | string;
+          try {
+            local = pool.poolMath.estimateSwap(
+              { ...state, ticks: { ...state.ticks } },
+              amount,
+              tokenAIn,
+              exactOutput,
+              tickLimit,
+            );
+          } catch (e: any) {
+            local = `throws: ${e?.message || e}`;
+          }
+          cases.push({
+            pool: pool.address,
+            label: `${pool.tokenA.symbol}/${pool.tokenB.symbol}`,
+            tokenAIn,
+            exactOutput,
+            amount,
+            local,
+          });
+          quoteCalls.push({
+            target: quoterAddress,
+            callData: quoterIface.encodeFunctionData('calculateSwap', [
+              pool.address,
+              amount,
+              tokenAIn,
+              exactOutput,
+              tickLimit,
+            ]),
+            decodeFunction: decodeQuote,
+          });
+        }
+      }
+    }
+  }
+  const quoteResults = await dexHelper.multiWrapper.tryAggregate<Pair>(
+    false,
+    quoteCalls,
+    blockNumber,
+    15,
+    false,
+  );
+
+  let matches = 0;
+  let mismatches = 0;
+  let onlyLocalThrows = 0;
+  let onlyOnchainFails = 0;
+  quoteResults.forEach(({ returnData: onchain }, i) => {
+    const c = cases[i];
+    const describe = `${c.label} pool=${c.pool} tokenAIn=${c.tokenAIn} exactOutput=${c.exactOutput} amount=${c.amount}`;
+    if (typeof c.local === 'string') {
+      if (onchain) {
+        onlyLocalThrows++;
+        console.log(
+          `LOCAL THROWS ${describe} local=${c.local} onchain=[${onchain}]`,
+        );
+      }
+      return;
+    }
+    if (!onchain) {
+      onlyOnchainFails++;
+      console.log(`ONCHAIN FAILS ${describe} local=[${c.local}]`);
+      return;
+    }
+    if (c.local![0] !== onchain[0] || c.local![1] !== onchain[1]) {
+      mismatches++;
+      console.log(
+        `QUOTE MISMATCH ${describe} local=[${
+          c.local
+        }] onchain=[${onchain}] dIn=${c.local![0] - onchain[0]} dOut=${
+          c.local![1] - onchain[1]
+        }`,
+      );
+    } else {
+      matches++;
+    }
+  });
+
+  console.log(
+    `RESULT network=${network} block=${blockNumber} ticks=${tickExpected.length} tickMismatches=${tickMismatches} quotes=${cases.length} matches=${matches} mismatches=${mismatches} onlyLocalThrows=${onlyLocalThrows} onlyOnchainFails=${onlyOnchainFails}`,
+  );
+  process.exit(mismatches || tickMismatches ? 1 : 0);
+})().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/dex/maverick-v2/scripts/compare-onchain-quotes.ts
+++ b/src/dex/maverick-v2/scripts/compare-onchain-quotes.ts
@@ -20,14 +20,16 @@ import { MaverickV2Config } from '../config';
 import { MaverickTickMath } from '../maverick-math/maverick-tick-math';
 import { PoolState } from '../types';
 import { extractSuccessAndValue } from '../../../lib/decoders';
-import { MultiResult } from '../../../lib/multi-wrapper';
+import { MultiCallParams, MultiResult } from '../../../lib/multi-wrapper';
 import QuoterABI from '../../../abi/maverick-v2/MaverickV2Quoter.json';
 import LensABI from '../../../abi/maverick-v2/MaverickV2PoolLens.json';
+import PoolABI from '../../../abi/maverick-v2/MaverickV2Pool.json';
 
 const network = Number(process.argv[2] || 1);
 const dexKey = 'MaverickV2';
 const quoterIface = new Interface(QuoterABI);
 const lensIface = new Interface(LensABI);
+const poolIface = new Interface(PoolABI);
 const MAX_UINT128 = (1n << 128n) - 1n;
 
 const AMOUNT_MULTIPLIERS: [bigint, bigint][] = [
@@ -83,7 +85,7 @@ const decodeTick = decodePair(lensIface, 'getTickSqrtPriceAndL', [
   console.log(`network=${network} block=${blockNumber} pools=${pools.length}`);
 
   // ticks
-  const tickCalls = [];
+  const tickCalls: MultiCallParams<Pair>[] = [];
   const tickExpected: { pool: string; tick: bigint; local: Pair }[] = [];
   for (const pool of pools) {
     const state = pool.getState(blockNumber) as PoolState;
@@ -141,7 +143,7 @@ const decodeTick = decodePair(lensIface, 'getTickSqrtPriceAndL', [
     local: Pair | string;
   };
   const cases: Case[] = [];
-  const quoteCalls = [];
+  const quoteCalls: MultiCallParams<Pair>[] = [];
   for (const pool of pools) {
     const state = pool.getState(blockNumber) as PoolState;
     for (const tokenAIn of [true, false]) {
@@ -196,19 +198,36 @@ const decodeTick = decodePair(lensIface, 'getTickSqrtPriceAndL', [
       }
     }
   }
-  const quoteResults = await dexHelper.multiWrapper.tryAggregate<Pair>(
-    false,
-    quoteCalls,
-    blockNumber,
-    15,
-    false,
-  );
+  // Quoter calls simulate a full swap, so keep multicall batches small and
+  // don't fire all of them at once
+  const QUOTES_PER_BATCH = 15;
+  const BATCHES_IN_FLIGHT = 20;
+  const quoteResults: MultiResult<Pair>[] = [];
+  for (
+    let start = 0;
+    start < quoteCalls.length;
+    start += QUOTES_PER_BATCH * BATCHES_IN_FLIGHT
+  ) {
+    quoteResults.push(
+      ...(await dexHelper.multiWrapper.tryAggregate<Pair>(
+        false,
+        quoteCalls.slice(start, start + QUOTES_PER_BATCH * BATCHES_IN_FLIGHT),
+        blockNumber,
+        QUOTES_PER_BATCH,
+        false,
+      )),
+    );
+  }
 
   let matches = 0;
   let mismatches = 0;
   let onlyLocalThrows = 0;
   let onlyOnchainFails = 0;
   let unfillableBuys = 0;
+  const onchainFailures = new Map<
+    string,
+    { count: number; callData: string }
+  >();
   quoteResults.forEach(({ returnData: onchain }, i) => {
     const c = cases[i];
     const describe = `${c.label} pool=${c.pool} tokenAIn=${c.tokenAIn} exactOutput=${c.exactOutput} amount=${c.amount}`;
@@ -228,7 +247,12 @@ const decodeTick = decodePair(lensIface, 'getTickSqrtPriceAndL', [
     }
     if (!onchain) {
       onlyOnchainFails++;
-      console.log(`ONCHAIN FAILS ${describe} local=[${c.local}]`);
+      const failures = onchainFailures.get(c.pool) || {
+        count: 0,
+        callData: quoteCalls[i].callData,
+      };
+      failures.count++;
+      onchainFailures.set(c.pool, failures);
       return;
     }
     if (c.local![0] !== onchain[0] || c.local![1] !== onchain[1]) {
@@ -244,6 +268,43 @@ const decodeTick = decodePair(lensIface, 'getTickSqrtPriceAndL', [
       matches++;
     }
   });
+
+  // The multicall drops revert data, so re-run one failing call per pool
+  // directly to get the reason
+  for (const [pool, { count, callData }] of onchainFailures) {
+    let reason = 'succeeds when called directly';
+    let revertData: string | undefined;
+    try {
+      // some nodes return the revert payload as the call result
+      const returned = await dexHelper.provider.call(
+        { to: quoterAddress, data: callData },
+        blockNumber,
+      );
+      try {
+        quoterIface.decodeFunctionResult('calculateSwap', returned);
+      } catch {
+        revertData = returned;
+      }
+    } catch (e: any) {
+      revertData = [e, e?.error, e?.error?.error]
+        .map(err => err?.data)
+        .find(d => typeof d === 'string' && d.startsWith('0x'));
+      if (!revertData) reason = e?.message || String(e);
+    }
+    if (revertData) {
+      reason = `revert data ${revertData.slice(0, 10)}`;
+      for (const iface of [poolIface, quoterIface]) {
+        try {
+          const parsed = iface.parseError(revertData);
+          reason = `${parsed.name}(${parsed.args.map(String).join(', ')})`;
+          break;
+        } catch {
+          // not an error of this interface
+        }
+      }
+    }
+    console.log(`ONCHAIN FAILS pool=${pool} calls=${count} reason=${reason}`);
+  }
 
   console.log(
     `RESULT network=${network} block=${blockNumber} ticks=${tickExpected.length} tickMismatches=${tickMismatches} quotes=${cases.length} matches=${matches} mismatches=${mismatches} unfillableBuys=${unfillableBuys} onlyLocalThrows=${onlyLocalThrows} onlyOnchainFails=${onlyOnchainFails}`,

--- a/src/dex/maverick-v2/scripts/compare-onchain-quotes.ts
+++ b/src/dex/maverick-v2/scripts/compare-onchain-quotes.ts
@@ -208,16 +208,22 @@ const decodeTick = decodePair(lensIface, 'getTickSqrtPriceAndL', [
   let mismatches = 0;
   let onlyLocalThrows = 0;
   let onlyOnchainFails = 0;
+  let unfillableBuys = 0;
   quoteResults.forEach(({ returnData: onchain }, i) => {
     const c = cases[i];
     const describe = `${c.label} pool=${c.pool} tokenAIn=${c.tokenAIn} exactOutput=${c.exactOutput} amount=${c.amount}`;
     if (typeof c.local === 'string') {
-      if (onchain) {
-        onlyLocalThrows++;
-        console.log(
-          `LOCAL THROWS ${describe} local=${c.local} onchain=[${onchain}]`,
-        );
+      if (!onchain) return;
+      // estimateSwap rejects a BUY the pool can't fill, the Quoter returns
+      // the partial fill; swap() prices both as 0
+      if (c.exactOutput && onchain[1] < c.amount) {
+        unfillableBuys++;
+        return;
       }
+      onlyLocalThrows++;
+      console.log(
+        `LOCAL THROWS ${describe} local=${c.local} onchain=[${onchain}]`,
+      );
       return;
     }
     if (!onchain) {
@@ -240,7 +246,7 @@ const decodeTick = decodePair(lensIface, 'getTickSqrtPriceAndL', [
   });
 
   console.log(
-    `RESULT network=${network} block=${blockNumber} ticks=${tickExpected.length} tickMismatches=${tickMismatches} quotes=${cases.length} matches=${matches} mismatches=${mismatches} onlyLocalThrows=${onlyLocalThrows} onlyOnchainFails=${onlyOnchainFails}`,
+    `RESULT network=${network} block=${blockNumber} ticks=${tickExpected.length} tickMismatches=${tickMismatches} quotes=${cases.length} matches=${matches} mismatches=${mismatches} unfillableBuys=${unfillableBuys} onlyLocalThrows=${onlyLocalThrows} onlyOnchainFails=${onlyOnchainFails}`,
   );
   process.exit(mismatches || tickMismatches ? 1 : 0);
 })().catch(e => {

--- a/src/dex/maverick-v2/types.ts
+++ b/src/dex/maverick-v2/types.ts
@@ -68,6 +68,9 @@ export type PoolState = {
   lastTwaD8: bigint;
   lastLogPriceD8: bigint;
   lastTimestamp: bigint;
+  feeAIn: bigint;
+  feeBIn: bigint;
+  protocolFeeRatioD3: bigint;
   bins: { [id: string]: Bin };
   ticks: { [id: string]: Tick };
 };

--- a/tests/utils-e2e.ts
+++ b/tests/utils-e2e.ts
@@ -179,6 +179,28 @@ type TestE2EOptions = {
   assertAmounts?: boolean;
 };
 
+// Tenderly rejects a block it hasn't indexed yet ("Unknown block number");
+// simulating on the route block's successor needs a short wait for it
+async function simulateWhenBlockIsKnown(
+  simulator: TenderlySimulator,
+  request: Parameters<TenderlySimulator['simulateTransaction']>[0],
+  attempts = 15,
+) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await simulator.simulateTransaction(request);
+    } catch (e: any) {
+      const message = e?.response?.data?.error?.message;
+      if (message !== 'Unknown block number' || attempt >= attempts) {
+        throw new Error(
+          `Tenderly simulation failed: ${message || e?.message || e}`,
+        );
+      }
+      await sleep(2000);
+    }
+  }
+}
+
 export async function testE2E(
   srcToken: Token,
   destToken: Token,
@@ -283,12 +305,16 @@ export async function testE2E(
     to,
     data,
     value,
-    blockNumber: priceRoute.blockNumber,
+    // Tenderly runs the tx as the first of `block_number`, i.e. on the state
+    // after the previous block, so +1 simulates on the route block's state
+    blockNumber: priceRoute.blockNumber + 1,
     stateOverride,
   };
   // simulate the transaction with overrides
-  const { transaction, simulation } =
-    await tenderlySimulator.simulateTransaction(simulationRequest);
+  const { transaction, simulation } = await simulateWhenBlockIsKnown(
+    tenderlySimulator,
+    simulationRequest,
+  );
   // log gas estimation if testing against API
   if (useAPI) {
     const estimatedGas = Number(priceRoute.gasCost);
@@ -404,11 +430,14 @@ export async function testPriceRoute(priceRoute: OptimalRate) {
     to,
     data,
     value,
-    blockNumber: priceRoute.blockNumber,
+    // Tenderly runs the tx as the first of `block_number`, i.e. on the state
+    // after the previous block, so +1 simulates on the route block's state
+    blockNumber: priceRoute.blockNumber + 1,
     stateOverride,
   };
   // simulate the transaction with overrides
-  const { simulation } = await tenderlySimulator.simulateTransaction(
+  const { simulation } = await simulateWhenBlockIsKnown(
+    tenderlySimulator,
     simulationRequest,
   );
   // release
@@ -526,11 +555,14 @@ export const testGasEstimation = async (
     to,
     data,
     value,
-    blockNumber: priceRoute.blockNumber,
+    // Tenderly runs the tx as the first of `block_number`, i.e. on the state
+    // after the previous block, so +1 simulates on the route block's state
+    blockNumber: priceRoute.blockNumber + 1,
     stateOverride,
   };
   // simulate the transaction with overrides
-  const { simulation } = await tenderlySimulator.simulateTransaction(
+  const { simulation } = await simulateWhenBlockIsKnown(
+    tenderlySimulator,
     simulationRequest,
   );
   // compare and assert


### PR DESCRIPTION
## Summary

Review of the MaverickV2 pricing math against the on-chain contracts, with fixes for the discrepancies found and two hot-path optimisations.

The pool-internal libraries (SwapMath, Delta, BinMath, TwaMath) are not published, so the math was verified empirically: `estimateSwap` was compared with the Quoter (`calculateSwap`, same `activeTick ± 100` tick limit as pricing) and `getTickSqrtPriceAndL` with the PoolLens, for every live pool on Mainnet, Base, Arbitrum and BSC, both directions, both sides, amounts from dust to 100+ tick crossings. With the fixes below every comparable quote and every tick matches exactly (16k+ quotes, 6.7k ticks, 0 mismatches).

### How to verify

`src/dex/maverick-v2/scripts/compare-onchain-quotes.ts` runs that comparison for one network at the current block and prints every mismatch plus a `RESULT` line (exit code 1 on any mismatch):

```bash
npx ts-node src/dex/maverick-v2/scripts/compare-onchain-quotes.ts 8453
```

Same block, master vs this branch (copy the script into a master checkout to reproduce):

| Network (block) | master | this branch |
|---|---|---|
| Base (51086262) | 7 quote mismatches, 8 tick mismatches | 0 / 0 |
| Mainnet (25940230) | 0 quote mismatches, 3 tick mismatches | 0 / 0 |

The Base quote mismatches are all on 3%-fee pools (API fee `0.03` vs on-chain `0.029999999999999999`); the tick mismatches are the one-sided `getTickL` rounding.

## Fixes

- **Fees from chain, not from the API.** The Maverick API returns rounded float fees (`0.03` where `fee()` is `29999999999999999`), which affected 42 pools across the four chains and every replayed `PoolSwap`. `feeAIn`, `feeBIn` and `protocolFeeRatioD3` now live in `PoolState`, are read on-chain in `generateState`, and are updated from `PoolSetVariableFee` / `PoolSetProtocolFeeRatio` events. `protocolFeeRatioD3` was previously hardcoded to 0.
- **`getTickL` one-sided branches** now match the on-chain `TickMath` (`divDown(reserveA, diff)` for `reserveB == 0`, and a separate `reserveA == 0` branch). The previous double rounding made tick liquidity low by up to ~90 units on live ticks.
- **Lens paging.** `getFullPoolState(pool, binStart, binEnd)` returns arrays indexed relative to `binStart`; bins are now keyed by `binStart + i` (latent, no pool has >5000 bins yet). `generateState` no longer swallows errors into an empty state; a not-yet-deployed pool (creation block) returns an empty pre-creation state instead, and `initializePricing` skips a pool that fails to initialise rather than failing the whole dex.
- Minor: dead overflow check in `mulDivDown` removed; `binIdsByTick` uses `delete` consistently (matches `generateState`, which omits zero ids).

## Optimisations

- `swap()` builds the temporary state with `Object.create(state.ticks)` instead of spreading the whole ticks map. The estimate path only reads ticks by key and replaces the ones it touches, so this is O(1) copy-on-write instead of O(#ticks) per quote.
- `MaverickPoolMath` memoises `tickSqrtPrices` per tick (constant for a given `tickSpacing`).
- `generateState` fetches pool state, fees and the first lens page in one multicall (a second one only for pools with more than 5000 bins).

Benchmark (`measure-calc-time.ts`, 20 amounts, USDC/USDT pool with 849 ticks): 3.35 ms → 0.33 ms per sweep; 187-tick pool: 1.39 ms → 0.20 ms. Outputs are identical to the previous implementation.

## Tests

- Integration test: Quoter tick limit is now `activeTick ± 100` (was an absolute ±100 and reverted on Base); expected on-chain value is 0 for a BUY that can't deliver the full amount, matching `swap()`; the monotonic price check runs on pools that fill every amount; pairs switched to deep pools (mainnet USDC/USDS, Base USDC/USDS).
- Events test: constructor no longer takes the (always 0) protocol fee.
- E2E: each case pins `poolIdentifiers` to the pool with the best full fill (the local SDK prices the first pool of the pair, whatever its depth). Pairs/amounts adjusted to available depth.
- `tests/utils-e2e.ts`: Tenderly executes the tx as the first of `block_number`, i.e. on the state after the previous block, so simulations now use `priceRoute.blockNumber + 1` with a retry on `Unknown block number` until Tenderly has indexed it.

Results on the final code: integration 9/9, events 67/67, e2e 20/20 (run per network; running all four networks back to back can hit mainnet RPC throttling during pool initialisation, which predates this change).

Follow-up (out of scope): the local e2e SDK prices on the state fetched at init time because the dummy block manager reports tracking but feeds no events, so pools arbitraged every block remain flaky under the 10 wei tolerance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core DEX swap and tick math plus fee state sourcing, so incorrect behavior would misquote trades across many pools; mitigated by on-chain parity checks and broad test updates.
> 
> **Overview**
> Aligns **MaverickV2** local pricing with on-chain Quoter/PoolLens and speeds up the quote hot path, with package version **5.1.16**.
> 
> **Correctness:** `feeAIn`, `feeBIn`, and `protocolFeeRatioD3` move into **`PoolState`**, loaded from chain in `generateState` and updated via **`PoolSetVariableFee`** / **`PoolSetProtocolFeeRatio`** (replacing API-rounded fees and a hardcoded zero protocol fee). **`getTickL`** one-sided reserve branches match on-chain **`TickMath`**. Lens **`getFullPoolState`** paging keys bins by **`binStart + i`**; pre-deploy blocks get an empty creation state instead of a swallowed-error empty state; failed pool init is skipped. Minor math/state tweaks: simplified **`mulDivDown`**, **`delete`** for empty **`binIdsByTick`** entries.
> 
> **Performance:** Per-tick **`tickSqrtPrices`** memoization; **`swap()`** uses **`Object.create(state.ticks)`** for copy-on-write during estimates; **`generateState`** batches state, fees, and the first lens page in one multicall.
> 
> **Tooling & tests:** Adds **`compare-onchain-quotes.ts`** for local vs on-chain tick/swap checks. Integration/E2E/events tests use **`activeTick ± 100`**, zero pricing for unfillable BUYs, pinned best pools, and stable pairs; **`testE2E`** simulates at **`blockNumber + 1`** with Tenderly retry for unknown blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4870ccc5cc0f8344d51c7eb907e229fcb846c31f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->