### PR TITLE
DEXLIB-304: pool reserves consumer harness (local reference, not deployed)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ local-scripts
 tests/debug-price-route.json
 .husky/.git-secrets-installed
 .claude/worktrees/
+
+# local redis dumps for pool-reserves simulation
+*.rdb
+*.resp

--- a/docs/pool-reserves-consumer-sim-plan.md
+++ b/docs/pool-reserves-consumer-sim-plan.md
@@ -1,0 +1,534 @@
+# Pool reserves consumer simulation — plan
+
+Revision 5, 2026-09-10 (revision 4 + code review round 2, §13; keys carry a Cluster hash tag). Companion to `docs/pool-reserves-plan.md` (the API
+this tool exercises; §6 public contract, §8 descriptor conventions, §21 open
+cost question for AlgebraIntegral). Revision 2 folds in the Codex plan
+review (§10) and the requirement that the consumer logic is written to be
+lifted into the production service as is.
+
+## 1. Goal
+
+Verify the full pool-reserves cycle end to end against real production data
+before the backend adopts the API: discover every dex that can produce
+reserves, read the mode-A storages the production cluster actually wrote,
+run `getPoolReserves` over them exactly the way the backend consumer will,
+persist the result, and make the numbers inspectable over HTTP.
+
+Two deliverables with different lifetimes:
+
+- **`consumer/`** — the sweep/collect/publish logic. Written as the reference
+  implementation of the production consumer: streaming, bounded memory,
+  bounded concurrency, no dependency on Express, tests or `DummyDexHelper`.
+  Its only inputs are a Redis client, a `getReserves(dexKey, pools?)`
+  function and a `PoolsStorage`. In production the function is an HTTP call
+  to dex-lib; here it is `PricingHelper.getPoolReserves` in-process.
+- **`server/`** — the local harness around it: dex-lib in slave mode on a
+  copy of the production dump, HTTP endpoints for inspection, verification
+  oracles, run reports. Throwaway.
+
+"Done" means: for Mainnet and Base, `POST /generate/:chainId` completes for
+every dex; every scanned field is accounted for as returned, skipped,
+duplicate or rejected; the oracles in §6 agree; the RPC cost per dex is
+written down in §8; and `consumer/` can be copied into the backend with only
+the `getReserves` binding changed.
+
+## 2. Decisions
+
+| #   | Decision                                                                           | Rationale                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| --- | ---------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| D1  | dex-lib runs as **slave** (`isSlave: true`)                                        | Matches the consumer's placement in production. Missing pieces are added to `DummyDexHelper` / `LocalParaswapSDK` as optional parameters (§3).                                                                                                                                                                                                                                                                                                                                               |
+| D2  | Redis: **filter the dump before loading**                                          | Dump is 9 GB, machine has 16 GB RAM. Keys are filtered to chains 1 and 8453 plus master block-number keys with a streaming RDB tool (§5), then piped into a fresh `redis-server` on port 6399. Fallback if the tool cannot parse the RDB version: full load with `--save ""`, RSS watched, abort near 13 GB and report the production run as blocked.                                                                                                                                        |
+| D3  | Backend composed-key format is **discovered from the dump**                        | `ICache.get/setex(dexKey, network, cacheKey)` compose a key the backend way; `DummyCache` uses `` `${network}_${dexKey}_${cacheKey}`.toLowerCase() ``. Hash keys are raw. `RedisCache` takes a `composeKey` function; the default is the `DummyCache` form and is confirmed or replaced after the §5 survey by checking a known consumer (`UniswapV2` `cache.get` of pool lists, `StatefulEventSubscriber` `hget(mapKey, name)`). `masterCachePrefix` is taken from the `<prefix>_1_bn` key. |
+| D4  | Output: **hash per dex per chain, published atomically, empty runs representable** | `dexlib:pools_reserves_legacy:{<dexKey>:<chainId>}`: field = `PoolReserves.id`, value = JSON `{ address, reserves, updatedAt, blockNumber }`. `…:meta` = run report (§4.4). Protocol in §4.3. The `{…}` is a Redis Cluster hash tag: production Redis is clustered and RENAME / MULTI / EVAL across `T`, `T:meta`, `T:tmp:*`, `T:lastFailure` need one slot.                                                                                                                                 |
+| D5  | `/pools` for mode B returns **ids from the last run**                              | Mode B has no storage. Response says `mode: 'enumerated'`, `source: 'last-run'`.                                                                                                                                                                                                                                                                                                                                                                                                             |
+| D6  | Chains: **Mainnet (1) and Base (8453)** first                                      | `POOL_RESERVES_CHAINS`; RPC from `HTTP_PROVIDER_<chainId>` in `.env`.                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| D7  | Initialization is **per dex, direct, with an explicit result**                     | `PricingHelper.initializeDex` swallows errors and retries forever, so it cannot report an outcome. The server calls `dex.initializePricing?.(blockNumber)` under a timeout → `ok / failed / timeout / none`. Because Ekubo, Maverick and WooFi swallow their own failures internally, a dex-specific readiness probe is added for those (§4.2).                                                                                                                                              |
+| D8  | **Live storage is consumed, no snapshot copy**                                     | Production reads live hashes while masters and slaves keep writing; so does the tool. To keep measurement honest the server records `HLEN` of each storage before dex-lib initialization and after, so descriptors published by this process (PoolsWriter starts on slaves too) are visible as the delta.                                                                                                                                                                                    |
+| D9  | **Streaming pipeline, O(batch × concurrency) memory**                              | UniswapV2 Mainnet storage has hundreds of thousands to millions of fields; nothing about a run may be proportional to that. No `Set` of seen fields, no array of all descriptors, no array of all results.                                                                                                                                                                                                                                                                                   |
+| D10 | **`getReserves` is injected**, not imported                                        | `consumer/` never touches `PricingHelper`; the harness binds it. The production service binds an HTTP client.                                                                                                                                                                                                                                                                                                                                                                                |
+| D11 | Code in `scripts/pool-reserves-server/`, current branch, one separate commit       | Depends on the four API commits; tooling, not library code. Own `tsconfig.json` for type-checking; own jest tests for `consumer/`.                                                                                                                                                                                                                                                                                                                                                           |
+| D12 | `ioredis` devDependency                                                            | Installed (`6.0.0`), lockfile diff limited to the new entry.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+
+## 3. Library changes (minimal, backward compatible)
+
+- `src/dex-helper/dummy-dex-helper.ts`: `DummyDexHelper(network, rpcUrl?, options?)`,
+  `options: { cache?: ICache; isSlave?: boolean; masterCachePrefix?: string }`.
+  `cache` replaces `DummyCache` before `AugustusApprovals` is constructed;
+  `isSlave` / `masterCachePrefix` feed `new ConfigHelper(...)`. Defaults
+  preserve today's behaviour.
+- `src/implementations/local-paraswap-sdk.ts`: fifth constructor parameter
+  `dexHelperOptions?` forwarded to `DummyDexHelper`. The `dexKeys` list stays
+  a public field so the harness can construct with `[]` and assign after
+  discovery (the pool-reserve dex list comes from the service the SDK
+  itself creates; a second SDK is not an option because
+  `StatePollingManager` keeps a per-network singleton bound to the first
+  helper).
+
+`pnpm checks` and existing unit tests stay green.
+
+## 4. Consumer module (`scripts/pool-reserves-server/consumer/`)
+
+Portable. Depends on `ioredis` types and `PoolsStorage` / `PoolReserves`
+from `src/types.ts` only.
+
+### 4.1 Sweep (`sweep.ts`)
+
+```ts
+type Batch = { fields: string[]; descriptors: string[] };
+async function* sweepStorage(
+  redis,
+  storage: PoolsStorage,
+  batchSize = MAX_POOL_RESERVES_BATCH,
+): AsyncGenerator<Batch>;
+```
+
+- `HSCAN key cursor COUNT batchSize` until cursor `'0'`. `COUNT` is a hint:
+  pages may be larger, smaller, empty. The generator refills an accumulator
+  and yields batches of exactly `batchSize` (last one shorter). A page is
+  never passed through as a batch.
+- Descriptor per field: `fieldInValue: true` → stored value verbatim.
+  `fieldInValue: false` → `{"i":<json field>,` + `value.slice(1)` when the
+  value starts with `{`; otherwise the field is counted `unparsable` and not
+  sent. No `JSON.parse` of the value on the hot path; the dex validates.
+- Duplicate fields (possible while the hash is being rehashed) are **not**
+  deduplicated here (D9). They are idempotent downstream: `HSET` overwrites,
+  and the per-batch reconciliation (§4.2) counts a field returned twice as
+  `duplicate`, not as an extra pool.
+- Yields `poolsInStorage` (`HLEN` at start) alongside for the report.
+
+### 4.2 Collect (`collect.ts`)
+
+```ts
+collectReserves({ dexKey, storage, getReserves, sink, concurrency = 3, onBatch }): Promise<CollectStats>
+```
+
+- Mode A: a fixed pool of `concurrency` workers pulls batches from one
+  shared `sweepStorage` iterator (async generators serialize concurrent
+  `next()` calls), so HSCAN advances only when a worker is free and is
+  throttled by RPC. No `Promise.race` over a growing set: every worker
+  settles before the run is finalized, so nothing can land after the report.
+  Concurrency default 3 per dex, dexes sequential per chain. Both knobs are
+  parameters; the report records them so §8 numbers are reproducible.
+- Mode B: single `getReserves(dexKey)`.
+- Per-batch reconciliation, O(batch): `requested = fields.length`;
+  returned rows whose `id` is in the batch's field set → `returned`;
+  a second row for the same `id` → `duplicate`; an `id` not in the set →
+  `unexpectedId` (counted, sample kept, row dropped: the consumer must not
+  persist ids it did not ask for); fields with no row → `skipped`
+  (count + sample ≤ 50 per dex). Mode B: `requested`/`skipped` are
+  `null`; `returned`, `duplicate` still apply.
+- Row validation before the sink (cheap, structural, same invariants as
+  `tests/utils-pool-reserves.ts`): `dex === dexKey`, `address` lowercase
+  hex, every `reserves` key is `token` or `token_token` lowercase, every
+  value is a decimal string or `UNLIMITED_RESERVES`. Violations → `invalid`
+  (count + sample), row dropped.
+- Rows go to the sink as they arrive; the sink pipelines `HSET` per batch
+  (§4.3). Nothing is retained after a batch is reconciled.
+- Errors: `getReserves` rejection → the batch is counted as `failedBatches`
+  with its fields as skipped, the run continues. `PoolReservesRequestError`
+  (the harness surfaces it as HTTP 400 in production) is **not** swallowed:
+  it means the consumer built a malformed request and the run is marked
+  `failed`. Sink errors abort the run (`failed`), see §4.3.
+- Timeouts are the dex-lib side's (`FETCH_POOL_RESERVES_TIMEOUT`): a timed
+  out batch comes back `[]` and counts as skipped. The report cannot tell a
+  timeout from a legitimate skip without dex-lib logs; the harness captures
+  those (§5.2 log capture), the production service will have them in its
+  own logging.
+- `zeroReserveRows`, `unlimitedRows` counted in passing.
+
+### 4.3 Publish (`publish.ts`)
+
+Keys: target `T = dexlib:pools_reserves_legacy:{<dexKey>:<chainId>}`,
+`T:meta`, `T:lastFailure`, temp `T:tmp:<runId>` (runId = ISO timestamp +
+random suffix). All share the hash tag, so they live in one Cluster slot.
+
+1. Sink writes each batch with one `EVAL` (`WRITE_SCRIPT`): for every write
+   after the first, `EXISTS tmp` or abort with `STAGING_MISSING`; `HSET`;
+   `EXPIRE 3600`. The TTL is refreshed on every write, an interrupted run
+   cannot leave garbage behind for longer than the TTL, and a staging hash
+   that expired or was evicted mid-run fails the run instead of being
+   recreated with only the later batches.
+2. On success, one `EVAL` (`PUBLISH_SCRIPT`):
+   - non-empty: `EXISTS tmp` or abort with `STAGING_MISSING`; `RENAME tmp T`;
+     `PERSIST T` (RENAME carries the staging TTL over); `SET T:meta`; `DEL
+T:lastFailure`.
+   - empty (`returned === 0`, legitimate for an empty inventory or an
+     all-disabled mode-B dex): `DEL T`; `SET T:meta`; `DEL T:lastFailure`.
+     `/reserves` then returns `total: 0` with the meta, distinct from 404
+     "never run".
+     A Lua script rather than MULTI because Redis does not roll back command
+     errors inside MULTI: a failed RENAME would still let the meta write
+     through.
+3. On failure (scan error, sink error, `PoolReservesRequestError`, a
+   throwing callback, a failed publish): `MULTI [DEL tmp; SET
+T:lastFailure]`; `T` and `T:meta` untouched. A rejected publish is
+   reported as "result may or may not be published": a lost EXEC
+   acknowledgement is indistinguishable from a refused one.
+4. A per-chain lock covers `POST /generate/:chainId` and
+   `POST /generate/:chainId/:dexKey`; overlapping requests get 409.
+
+### 4.4 Report (`CollectStats`, stored as `T:meta`)
+
+```ts
+{
+  dexKey, chainId, mode: 'storage' | 'enumerated', storageKey, fieldInValue,
+  runId, startedAt, finishedAt, durationMs, blockNumber,
+  concurrency, batchSize,
+  poolsInStorage: number | null,         // HLEN at sweep start
+  poolsInStorageBeforeInit: number | null, // harness-only, D8
+  scannedFields, unparsable, requested, returned, skipped, duplicate,
+  unexpectedId, invalid, failedBatches, batches,
+  skippedSample: string[], unexpectedIdSample: string[], invalidSample: string[],
+  zeroReserveRows, unlimitedRows,
+  rpc: { jsonRpcRequests, multicallSubCalls },  // harness-only, §5.2
+  warnings: string[],                            // harness-only, captured dex-lib warn/error logs
+  status: 'ok' | 'failed', failure?: string
+}
+```
+
+### 4.5 Tests (`consumer/*.test.ts`, jest, fake Redis in memory)
+
+- Sweep: page larger than `batchSize` is re-chunked; empty intermediate
+  pages; last partial batch; `fieldInValue: false` wrapping; non-object
+  value → `unparsable`.
+- Collect: duplicate field returned twice → `duplicate: 1`, one row
+  persisted; `unexpectedId` dropped; invalid row dropped; concurrency cap
+  respected (assert max in-flight); rejected batch → `failedBatches: 1`,
+  fields counted skipped, run `ok`; `PoolReservesRequestError` → run
+  `failed`, no publish.
+- Publish: non-empty → `RENAME` + meta atomically; empty → `DEL` + meta;
+  failure → previous `T` and `T:meta` intact, tmp deleted; non-empty →
+  empty replacement removes obsolete ids.
+
+## 5. Harness (`scripts/pool-reserves-server/server/`)
+
+### 5.1 Files
+
+| File                 | Content                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `redis-cache.ts`     | `RedisCache implements ICache` over `ioredis` (D3). Composed-key methods use `composeKey`; hash/set/zset/raw methods map 1:1; `hscan` returns `{ cursor, entries }`; `publish`/`subscribe` on a duplicated connection; `addBatchHGet` = immediate `hget`; the `*AndCacheLocally` variants do not cache.                                                                                                                                                                                                                                                                                                         |
+| `chain-context.ts`   | Per chainId: `new LocalParaswapSDK(network, [], rpcUrl, undefined, { cache, isSlave: true, masterCachePrefix })`; `dexKeys = Object.keys(dexAdapterService.getPoolsStorages())`; asserts every key passes `getDexByKey` (no legacy pool-tracker dex implements `getPoolReserves` today; a difference is logged). Records `HLEN` per storage **before** initialization (D8). D7 initialization with timeout (default 120 s) and readiness probes: EkuboV3 `poolManager.poolsByString.size > 0`; MaverickV2 `pools.length > 0`; WooFiV2 poller state present. Installs the RPC counter and log capture from §5.2. |
+| `instrumentation.ts` | Wraps `dexHelper.provider.send` and `web3Provider.currentProvider.send` to count JSON-RPC requests, and `multiWrapper.aggregate/tryAggregate` to count multicall sub-calls. A log4js appender registered on the dex-lib categories collects `warn`/`error` lines while a dex is being initialized or collected; the harness attributes them by phase (`init` / `collect`) because dexes run one at a time. Background timers from other dexes can still leak into a window; the report notes this and counts are labelled as upper bounds.                                                                      |
+| `verify.ts`          | §6 oracles.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `index.ts`           | Express app, env, CLI flags `--generate`, `--exit`, graceful shutdown: `releaseResources` for every context with a 30 s bound, then `redis.quit()`, then `process.exit`. `PricingHelper.releaseDexResources` retries forever on failure, so the bound is needed.                                                                                                                                                                                                                                                                                                                                                |
+| `tsconfig.json`      | Extends root, `rootDir: ../..`, `noEmit`, includes `./**/*.ts` and `../../src/**/*.ts`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `redis-local.sh`     | §5.3 steps.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| `README.md`          | Run instructions, endpoints, report fields, and a "porting to production" section listing what `consumer/` needs from its host (Redis client, `getReserves`, logger).                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+
+### 5.2 Endpoints
+
+| Route                                                         | Response                                                                                                                                                                                                                                             |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `GET /health`                                                 | `{ ok, chains: [{ chainId, ready }] }`                                                                                                                                                                                                               |
+| `GET /dexs/:chainId`                                          | `{ chainId, dexs: [{ dexKey, mode, storage, init: { status, readiness?, durationMs, error? }, poolsInStorageBeforeInit, poolsInStorageNow }] }`                                                                                                      |
+| `GET /pools/:dexKey/:chainId?cursor=&count=`                  | mode A: one `HSCAN` page → `{ mode: 'storage', key, fieldInValue, total (HLEN), cursor, pools: [{ id, descriptor }] }`; mode B: `{ mode: 'enumerated', source: 'last-run', total, cursor, ids }` (D5). Paginated, never a full scan in one response. |
+| `GET /pools/:dexKey/:chainId/:id`                             | `HGET` of one descriptor (mode A) or one stored row (mode B); 404 if absent. Used to classify `skippedSample` entries.                                                                                                                               |
+| `GET /reserves/:dexKey/:chainId?cursor=&count=`               | `{ meta, total, cursor, reserves: [...] }`; 404 when `T:meta` absent; `total: 0` with meta after an empty run.                                                                                                                                       |
+| `GET /reserves/:dexKey/:chainId/:id`                          | one row.                                                                                                                                                                                                                                             |
+| `POST /generate/:chainId` / `POST /generate/:chainId/:dexKey` | Runs `collectReserves` (all dexes sequentially / one); returns `{ chainId, blockNumber, reports }`; 409 while a run is active on the chain.                                                                                                          |
+| `GET /status/:chainId`                                        | `{ init, running: dexKey \| null, lastRun, lastFailures }`                                                                                                                                                                                           |
+| `GET /verify/:dexKey/:chainId?sample=50`                      | §6.                                                                                                                                                                                                                                                  |
+
+Unknown chain → 404; unknown dexKey → 404 with known keys;
+`PoolReservesRequestError` → 400 (and the run is `failed`, §4.2).
+
+### 5.3 Loading the production dump
+
+1. Survey without loading: `redis-rdb-cli` (`rct -f count`, `rct -f mem -l 200`),
+   version pinned in `redis-local.sh`. Output: key patterns, sizes, types,
+   source DB index, RDB version. Answers D3 and confirms which mode-A
+   storages exist.
+2. Filter: `rct -f resp -k '<regex>'` with the regex written from step 1
+   (chains 1 and 8453, master block-number keys). Record excluded key
+   counts.
+3. `redis-server --port 6399 --save "" --appendonly no --dir <tmpdir>`.
+4. `redis-cli -p 6399 --pipe < filtered.resp`; record `DBSIZE`, import
+   errors, and `HLEN` of every expected storage key into §8.
+5. Expiry: RDB stores absolute expiry times; keys expired since the backup
+   vanish on load. Slave-mode state misses fall back to `generateState`
+   over RPC, as a real slave would. Their cost lands in the `init` phase
+   counters, not the sweep.
+
+## 6. Verification (per chain)
+
+### 6.1 Coverage
+
+1. `GET /dexs/:chainId` lists every §2.1 dex of the API plan configured on
+   the chain as `storage` and every §2.2 dex as `enumerated`. Missing key →
+   finding.
+2. For every mode-A storage, `poolsInStorageBeforeInit` is recorded. Zero
+   means the dump holds no production inventory for that dex; the dex is
+   marked **not verified on production data** in §8 (a locally published
+   inventory is still swept, so the code path runs, but it is not the
+   production input). Zero is a fact to explain (filter, expiry, dex
+   deployed after the backup), not a pass.
+3. Mode B: for each dex the expected set of ids comes from the dex's own
+   configuration on that chain (the same source `getPoolIdentifiers`
+   uses); rows may legitimately be absent for frozen/paused pools
+   (AaveGsm frozen, WooFi paused) and the report lists absent ids so the
+   reason can be checked. Directional/plain key shapes and `unlimited`
+   placement are checked against the §7 table of the API plan for every
+   returned row, not spot-checked.
+
+### 6.2 Accounting
+
+4. For every mode-A dex: `scannedFields === returned + skipped + duplicate + unparsable`
+   (identity on the report), `unexpectedId === 0`, `invalid === 0`,
+   `failedBatches === 0`, `status: 'ok'`.
+5. `skipped / requested` recorded per dex; investigation threshold > 20 %
+   for UniswapV2 / Solidly families and any non-zero `unparsable` on
+   PancakeSwapV2. Each `skippedSample` entry is classified via
+   `GET /pools/:dexKey/:chainId/:id` (legacy format, invalid pool,
+   token contradiction, RPC failure seen in `warnings`).
+
+### 6.3 Values
+
+Oracles are protocol-specific and block-aware. The tool has dex instances
+in-process, so for state-derived values it reads the pool's
+`getStateBlockNumber()` and compares at that block, not at latest.
+
+6. UniswapV2 / Solidly (RPC path): re-read `getReserves()` at the block the
+   run recorded; equality expected for pools that had no swap in between;
+   pools that differ are re-read at latest and must match one of the two.
+   `sample=50`, pass if ≥ 45 match.
+7. MaverickV2 / Algebra / AlgebraIntegral (state path): `balanceOf` of both
+   tokens at the pool's state block must equal the stored values exactly.
+8. EkuboV3: no on-chain oracle for virtual TVL. Check: the set of returned
+   ids equals the set of pool keys in `poolManager` minus invalid pools;
+   values are non-negative decimals; no `unlimited`.
+9. Mode B: each dex's capacity rule from the §7 table is re-derived from a
+   direct contract read at the run block for one dex per family (LitePsm
+   `gem` balances, AaveGsm exposure cap arithmetic, ERC4626 `totalAssets`).
+10. Agreement is counted per pool: all tokens of the pool must agree. Zero
+    denominators are handled with bigint comparison, never floats. Failed
+    oracle calls are reported as `unverified`, not as agreement. Fewer
+    eligible pools than `sample` → all of them, and the report says so.
+    Missing production data or an unavailable oracle yields "not
+    verified", which blocks an overall pass for that dex.
+
+### 6.4 Behaviour
+
+11. Second `POST /generate` on the same chain while one runs → 409; a later
+    one succeeds and readers saw complete data throughout (spot-check with
+    a polling reader during the run).
+12. Non-empty → empty replacement removes obsolete ids; killing Redis
+    mid-run leaves `T`/`T:meta` from the previous run intact and a
+    `lastFailure`.
+13. `SIGINT` exits within 30 s with no leaked timers.
+14. `pnpm checks`, `pnpm test src/lib/pools-storage src/dex/pool-reserves`,
+    `npx tsc -p scripts/pool-reserves-server/tsconfig.json`, and
+    `npx jest scripts/pool-reserves-server/consumer` green.
+
+## 7. Risks
+
+- **Memory**: D2 filtering and D9 streaming; Redis RSS and node heap are
+  recorded after a full Mainnet run.
+- **RPC load**: sequential dexes, `concurrency` capped, private providers.
+  Rate limiting is invisible to the consumer's own counters (dex-lib swallows
+  it); the harness catches it in `warnings`. The production service must
+  rely on dex-lib logs for the same signal — documented in the README.
+- **State freshness**: `DummyBlockManager` processes no logs; state loaded
+  from the dump stays at the dump's block and state generated at init stays
+  at the init block. Production slaves have a live block manager. Values
+  from the state path are therefore verified at the state block (§6.3),
+  and the report carries `blockNumber` of the run plus, for state-path
+  dexes, the min/max state block seen.
+- **Slave initialization side effects**: PoolsWriter flushes on slaves,
+  AlgebraIntegral `updatePoolsTvl` runs with `DummyDexHelper`'s fake USD
+  pricing, so locally published inventories are not production-equivalent.
+  D8 makes the delta visible; only pre-init inventories count as
+  production input.
+- **Dump staleness**: descriptors may reference pools that changed after
+  the backup; reserves are read now. That is the real consumer situation.
+
+## 8. Measurements — run 1, 2026-09-10
+
+Dump: `pool-tracker-deprecation-backup-0001.rdb` (RDB v10, Redis 7.1,
+`used-mem` 10.7 GB, 2.46 M keys). Filtered to chains 1 and 8453 + `is_*`:
+19 669 keys, 4.63 GB in Redis. `concurrency=3`, `batchSize=1000`, slave
+mode, `masterCachePrefix=is`. Whole-chain runs: Mainnet 48 dexes in 47 s,
+Base 16 dexes in 54 s. Node RSS after both runs: 221 MB (Mainnet
+instance), 128 MB (Base instance).
+
+Mode A (production inventories; `rpc` = JSON-RPC requests during the sweep):
+
+| chain | dexKey                                | poolsInStorageBeforeInit | scanned   | returned | skipped % | rpc | ms     | verified                        |
+| ----- | ------------------------------------- | ------------------------ | --------- | -------- | --------- | --- | ------ | ------------------------------- |
+| 1     | UniswapV2                             | 452 980                  | 452 980   | 50 526   | 88.8      | 453 | 14 188 | getReserves 50/50 at run block  |
+| 1     | SushiSwap                             | 493 749                  | 493 749   | 2 308    | 99.5      | 489 | 9 288  | –                               |
+| 1     | ShibaSwap                             | 493 688                  | 493 688   | 433      | 99.9      | 292 | 7 924  | –                               |
+| 1     | DefiSwap                              | 493 741                  | 493 741   | 98       | 99.98     | 93  | 4 217  | –                               |
+| 1     | Verse                                 | 493 736                  | 493 736   | 29       | 99.99     | 29  | 4 863  | –                               |
+| 1     | RingV2                                | 405 645                  | 405 645   | 67       | 99.98     | 64  | 4 506  | –                               |
+| 1     | PancakeSwapV2 (`fieldInValue: false`) | 7 983                    | 7 983     | 7 983    | 0         | 16  | 1 825  | getReserves 30/30               |
+| 8453  | UniswapV2                             | 452 307                  | 452 307   | 29 455   | 93.5      | 453 | 13 099 | getReserves 50/50               |
+| 8453  | Aerodrome                             | 921 696                  | 921 696   | 5 151    | 99.4      | 920 | 17 283 | getReserves 49/50 + 1 at latest |
+| 8453  | Equalizer                             | 921 636                  | 921 636   | 294      | 99.97     | 254 | 10 171 | –                               |
+| 8453  | Alien                                 | 1 473 412                | 1 473 412 | 400      | 99.97     | 348 | 13 530 | –                               |
+
+Mode A storages absent from the dump (dexes deployed after the backup),
+swept from the locally published inventory only:
+
+| chain | dexKey      | published locally | returned | rpc | verified                                                 |
+| ----- | ----------- | ----------------- | -------- | --- | -------------------------------------------------------- |
+| 1     | EkuboV3     | 123               | 123      | 0   | id set = pool manager 123/123                            |
+| 1     | MaverickV2  | 68                | 68       | 0   | balanceOf: 53 exact, 8 within 1e-6, 7 lag (see §11)      |
+| 1     | Supernova   | 9                 | 9        | 1   | –                                                        |
+| 8453  | MaverickV2  | 114               | 114      | 0   | balanceOf: 109 agree, 5 differ (see §11)                 |
+| 8453  | QuickSwapV4 | 51                | 51       | 1   | balanceOf: 49 agree, 1 active pool 1.5 % off (state lag) |
+
+Mode B: 38 dexes on Mainnet and 10 on Base, all `status: ok`, one
+`getPoolReserves` call each, 0–4 RPC requests. Row counts: AaveV3 67/15,
+AaveV3Stata 28/7, AaveV3StataV2 16/13, AaveV3Lido 9, AngleTransmuter 2,
+Swell 2, OSwap 2, everything else 1. AaveGsm returned 0 rows: both Mainnet
+GSMs (`GSM_USDC`, `GSM_USDT`) report `getIsSeized() == true` on-chain, so
+omission is the specified behaviour.
+
+Accounting identities held on every dex: `scanned = requested + unparsable`,
+`requested = returned + invalid + skipped + duplicateFields`, with
+`unparsable = invalid = unexpectedId = duplicateFields = duplicateRows =
+failedBatches = 0` everywhere and no captured warnings except one OSwap
+`generateState` revert during its run (2 rows still returned).
+
+Cost: UniswapV2-family sweeps make one multicall per batch of 1000
+descriptors, containing only the pairs that exist (50 526 sub-calls in 453
+requests for UniswapV2 Mainnet), ≈ 30 ms per 1000 descriptors end to end
+including HSCAN. The 1.47 M-field Alien hash sweeps in 13.5 s.
+
+## 9. Out of scope
+
+- The production service itself (HTTP binding of `getReserves`, scheduling,
+  metrics export, auth). `consumer/` is written for it; wiring is theirs.
+- Backend `ICache.hscan` implementation (`RedisCache` here is a reference).
+- Pruning behaviour (covered by `pools-writer.test.ts`).
+- Other chains in the first pass.
+
+## 10. Plan review — responses
+
+Codex Plan Reviewer, round 1 (REJECT). Accepted: HSCAN re-chunking and
+duplicate handling (§4.1); per-batch reconciliation with `unexpectedId`
+and `duplicate` instead of `requested − returned` (§4.2); empty/failed run
+publication protocol and chain lock on both routes (§4.3); log capture and
+provider-level RPC counting because dex-lib swallows RPC failures (§5.1);
+pre-init `HLEN` because PoolsWriter runs on slaves (D8); state-block
+oracles because `DummyBlockManager` never advances state (§6.3, §7);
+readiness probes for Ekubo/Maverick/WooFi (D7); SDK construction order and
+the `toLowerCase()` in D3; paginated `/pools` plus single-id lookup (§5.2);
+bounded shutdown (§5.1).
+
+Partially accepted: the coverage matrix is reduced to per-dex expected ids
+from the dex's own configuration and the §7 key-shape rules applied to
+every row, not independently sourced inventories; RPC attribution is by
+phase (`init` / `collect`) only.
+
+Rejected: keeping a snapshot copy of storages for the sweep — production
+reads live hashes and so does the tool (D8 replaces it).
+
+## 11. Run 1 findings
+
+1. **Skip ratio is dominated by non-existent pairs.** 40/40 sampled
+   UniswapV2 and 30/30 Aerodrome skipped descriptors are
+   `{ token0, token1, checkExistenceAfter }` without `exchange`: pairs the
+   factory reported as absent, cached to avoid re-asking. The dex drops
+   them without RPC. So the §6.2 threshold of 20 % is meaningless for this
+   family; the useful check is "every skipped descriptor lacks `exchange`",
+   which held. For the production consumer this means ~90 % of the bytes
+   read from UniswapV2-family hashes are placeholders; the sweep still costs
+   ≈ 13–17 s per 450 k–1.5 M fields, so no change is needed now.
+2. **State-path oracles need to run right after generation.** MaverickV2
+   refreshes pool state on its own timer, so by the time `/verify` runs the
+   in-memory state block has moved past the run block and the stored value
+   reflects an older state. Remaining "disagree" rows on Mainnet are all
+   < 0.1 % apart on active pools. One Base MaverickV2 pool
+   (`0x6e4cf8db78ec226c3655d4243669d61e29ff192d`) reports `reserveA`
+   4 601 682 against a token balance of 5.04e16 — worth a look by the
+   Maverick maintainer, not a consumer issue.
+3. **Slave initialization is cheap here**: 48 dexes in 5.9 s on Mainnet,
+   16 in 3.4 s on Base, because UniswapV2 pools are created lazily and the
+   mode-B dexes are single contracts. Expired master state was not a
+   factor for the pool-reserve dexes.
+4. **ts-node module resolution**: `import … from './bebop/bebop'` resolves
+   to `bebop.json` under plain ts-node, leaving an `undefined` in `Dexes`.
+   The npm script sets `TS_NODE_PREFER_TS_EXTS=true`; jest and `tsc`
+   builds are unaffected.
+5. **ioredis MULTI takes lowercase method names**; the first publish
+   attempt failed on `RENAME` and, because `discard` used the same path,
+   left `…:tmp:<runId>` hashes behind. Their 3600 s TTL is what cleans
+   them up, which is exactly the case the TTL was added for.
+6. `SIGINT` on an idle instance exits immediately; `releaseResources` is
+   bounded at 30 s.
+
+## 12. Code review round 1 — responses
+
+Codex Code Reviewer (gpt-6-astra), REQUEST CHANGES. All seven critical items
+fixed and covered by tests:
+
+1. `RENAME` carries the staging TTL to the published hash — confirmed on the
+   local Redis (`ttl=2788` on `UniswapV2:1` after the first run). Publish
+   now runs a Lua script with `PERSIST` (§4.3); `FakeRedis` transfers TTLs
+   on RENAME so the test would have caught it.
+2. Staging expiry mid-run / MULTI not rolling back: `EXPIRE` refreshed on
+   every write, publish aborts on `STAGING_MISSING` before touching meta.
+3. Scan exceptions abandoned in-flight workers and `onBatch` rejections
+   escaped: replaced the `Promise.race` loop with a fixed worker pool that
+   drains before finalization; `processBatch` never rejects; a throwing
+   callback fails the run.
+4. `HLEN`/publish outside the failure lifecycle: finalization is inside it,
+   `lastFailure` is written, the ambiguity of a lost EXEC ack is stated in
+   the failure message.
+5. `batchSize: 1.5` produced a 1001-descriptor request, `NaN` concurrency
+   removed the cap: `Number.isSafeInteger` bounds on both.
+6. Shared `LogCapture` across chains: independent windows, every event
+   lands in all open ones (upper bound, as documented), closed in the error
+   path too.
+7. Negative `?sample=` made `HRANDFIELD` sample with replacement: integer
+   `1..500` enforced.
+
+Recommendations: `validateRow` accepts `unknown` and a non-array response is
+one `invalid`; `/reserves` reads meta, rows and count in one MULTI;
+`/verify` takes the run block from the published meta; readiness probes
+yield `status: 'unready'`; `msetex` surfaces pipeline errors; `subscribe`
+reference-counts channel listeners and logs subscription failures. The
+`Promise.race` reaction accumulation is gone with the worker pool.
+
+Codex confirmed `zadd` ordering, empty `hmset`, provider `this` binding,
+`HRANDFIELD WITHVALUES` parsing and the bigint tolerance arithmetic. Tests:
+32 in `consumer/` (from 23), covering TTL refresh and PERSIST, expired
+staging, failed publish transaction, scan failure with active workers,
+throwing callback, fatal stop, cross-batch duplicate, null / non-array
+responses, non-integer parameters.
+
+## 13. Code review round 2 — responses
+
+Codex Code Reviewer (gpt-6-astra), REQUEST CHANGES: five of seven round-1
+items confirmed fixed, two partially, one new race, one deployment
+question.
+
+- **Staging expiry between writes** recreated the hash with only the later
+  batches: writes after the first now go through `WRITE_SCRIPT`, which
+  aborts with `STAGING_MISSING` when the hash is gone (§4.3). Reproduced by
+  the reviewer, now a unit test and a real-Redis test.
+- **`onBatch` not awaited**: awaited; the callback type is `void |
+Promise<void>`; an async rejection fails the run with no unhandled
+  rejection (test listens for `unhandledRejection`).
+- **`/verify` mixed runs**: metadata, `HRANDFIELD` sample and `HLEN` are
+  read in one MULTI.
+- **Non-array response** broke the accounting identity: counted as a failed
+  batch with its fields skipped, so `requested = returned + invalid + skipped
+  - duplicateFields` holds; test asserts the identity.
+- **WooFi readiness** checked object presence: it now awaits
+  `pollingPool.getState()` under a 10 s timeout.
+- **Redis Cluster**: production is clustered (confirmed by the owner), so
+  the keys carry a hash tag (D4). Kept to that one change; no client-side
+  slot handling.
+- **Tests**: the TTL test lowers the fake TTL between writes and expects
+  the reset; the drain test faults the scan while one request is
+  outstanding and asserts it completes before discard; added final `HLEN`
+  failure and `publish.redis.test.ts`, an opt-in suite
+  (`POOL_RESERVES_TEST_REDIS_URL`) that runs both Lua scripts against a real
+  Redis, including a 1000-row write, so a missing `PERSIST` would be caught
+  outside the hand-written fake. 42 tests in `consumer/` (from 32).
+
+Re-run on the local production copy after the changes: Mainnet 48 dexes in
+45 s, all `ok`, 61 800 rows published, published hashes `ttl=-1`, UniswapV2
+`getReserves` 50/50 at the run block.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testRegex: [
     '/tests/.*\\.(test|spec)\\.(ts)$',
     '/src/(dex|lib|executor)/.*\\.(test|spec)\\.(ts)$',
+    '/scripts/pool-reserves-server/.*\\.(test|spec)\\.(ts)$',
   ],
   moduleFileExtensions: ['ts', 'js', 'json', 'node'],
   testTimeout: 30 * 1000,

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-plugin-import": "^2.26.0",
     "express": "^4.18.2",
     "husky": "^8.0.2",
+    "ioredis": "^6.0.0",
     "jest": "^30.2.0",
     "prettier": "^2.8.1",
     "pretty-quick": "^3.1.3",
@@ -46,6 +47,7 @@
   "scripts": {
     "init-integration": "ts-node scripts/dex-integration.ts init",
     "test-integration": "ts-node scripts/dex-integration.ts test",
+    "pool-reserves-server": "TS_NODE_PREFER_TS_EXTS=true ts-node -T scripts/pool-reserves-server/server/index.ts",
     "build": "pnpm run check:pq && pnpm run check:es && tsc",
     "watch": "tsc -w",
     "test": "jest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,9 @@ importers:
       husky:
         specifier: ^8.0.2
         version: 8.0.3
+      ioredis:
+        specifier: ^6.0.0
+        version: 6.0.0
       jest:
         specifier: ^30.2.0
         version: 30.4.2(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
@@ -864,6 +867,12 @@ packages:
         integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==,
       }
     deprecated: Use @eslint/object-schema instead
+
+  '@ioredis/commands@2.0.0':
+    resolution:
+      {
+        integrity: sha512-vrx0AE/T0h7cRZwfo1M39Cr+ZhZrkf0V8mQN75wucKCxCLD9l/VX6no3gFvrLqD1IlG/1LtzWovqEw3t0Vr9zg==,
+      }
 
   '@isaacs/cliui@8.0.2':
     resolution:
@@ -2624,6 +2633,13 @@ packages:
       }
     engines: { node: '>=0.8' }
 
+  cluster-key-slot@1.1.1:
+    resolution:
+      {
+        integrity: sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==,
+      }
+    engines: { node: '>=0.10.0' }
+
   co@4.6.0:
     resolution:
       {
@@ -2964,6 +2980,13 @@ packages:
         integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==,
       }
     engines: { node: '>=0.4.0' }
+
+  denque@2.1.0:
+    resolution:
+      {
+        integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==,
+      }
+    engines: { node: '>=0.10' }
 
   depd@2.0.0:
     resolution:
@@ -4127,6 +4150,13 @@ packages:
         integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==,
       }
     engines: { node: '>= 0.4' }
+
+  ioredis@6.0.0:
+    resolution:
+      {
+        integrity: sha512-f+Dtubxfpf6KYFq7WVXJoOLn0bk4TJrMrN9SzeE+jrWrCWj7XX3fA6vkryafhADX+GMymRxgDJDOI33COkJc0w==,
+      }
+    engines: { node: '>=20.0.0' }
 
   ipaddr.js@1.9.1:
     resolution:
@@ -5818,6 +5848,13 @@ packages:
       }
     engines: { node: '>= 6' }
 
+  redis-errors@1.2.0:
+    resolution:
+      {
+        integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==,
+      }
+    engines: { node: '>=4' }
+
   reflect.getprototypeof@1.0.10:
     resolution:
       {
@@ -6189,6 +6226,12 @@ packages:
         integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==,
       }
     engines: { node: '>=10' }
+
+  standard-as-callback@2.1.0:
+    resolution:
+      {
+        integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==,
+      }
 
   statuses@2.0.2:
     resolution:
@@ -7903,6 +7946,8 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
+  '@ioredis/commands@2.0.0': {}
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -9108,6 +9153,8 @@ snapshots:
 
   clone@2.1.2: {}
 
+  cluster-key-slot@1.1.1: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.3: {}
@@ -9293,6 +9340,8 @@ snapshots:
   delay@5.0.0: {}
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@2.0.0: {}
 
@@ -10214,6 +10263,17 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  ioredis@6.0.0:
+    dependencies:
+      '@ioredis/commands': 2.0.0
+      cluster-key-slot: 1.1.1
+      debug: 4.4.3
+      denque: 2.1.0
+      redis-errors: 1.2.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ipaddr.js@1.9.1: {}
 
@@ -11362,6 +11422,8 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  redis-errors@1.2.0: {}
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -11657,6 +11719,8 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
 

--- a/scripts/pool-reserves-server/README.md
+++ b/scripts/pool-reserves-server/README.md
@@ -1,0 +1,131 @@
+# Pool reserves consumer simulation
+
+Local harness that runs the pool-reserves consumer flow end to end against a
+copy of the production Redis: discover every dex exposing `getPoolReserves`,
+sweep the mode-A storages the production cluster wrote, call
+`getPoolReserves` in batches, publish the result to
+`dexlib:pools_reserves_legacy:{<dexKey>:<chainId>}` (the braces are a Redis Cluster hash tag so the hash, its `:meta`, `:tmp:<runId>` and `:lastFailure` share a slot) and make everything inspectable over HTTP. Plan and design notes:
+`docs/pool-reserves-consumer-sim-plan.md`.
+
+Two parts:
+
+- `consumer/` — the sweep → collect → validate → publish logic, written as
+  the reference implementation for the production consumer. No Express, no
+  dex-lib internals; inputs are a `ConsumerRedis` (seven commands), a
+  `getReserves(dexKey, pools?)` function and a `PoolsStorage`.
+- `server/` — the harness: dex-lib in slave mode over the local Redis copy,
+  initialization with explicit outcomes, RPC/log instrumentation, endpoints,
+  verification oracles.
+
+## Running
+
+1. Load the dump (filters to the chains you need; ~4.6 GB for 1 + 8453):
+
+   ```bash
+   scripts/pool-reserves-server/redis-local.sh /path/to/dump.rdb 1,8453 6399
+   ```
+
+   Needs `redis-server` and [redis-rdb-cli](https://github.com/leonchen83/redis-rdb-cli)
+   (`RCT=/path/to/rct`). RDB v10 (Redis 7.1) dumps load into redis-server 8.x.
+
+2. Start the server (RPC URLs come from `HTTP_PROVIDER_<chainId>` in `.env`):
+
+   ```bash
+   POOL_RESERVES_CHAINS=1,8453 pnpm pool-reserves-server
+   # one full pass over every chain, print the table, exit:
+   pnpm pool-reserves-server -- --generate --exit
+   ```
+
+   | env                             | default                  | meaning                                               |
+   | ------------------------------- | ------------------------ | ----------------------------------------------------- |
+   | `POOL_RESERVES_REDIS_URL`       | `redis://127.0.0.1:6399` | the local copy, never production                      |
+   | `POOL_RESERVES_PORT`            | `3400`                   | HTTP port                                             |
+   | `POOL_RESERVES_CHAINS`          | `1,8453`                 | chain ids to initialize                               |
+   | `POOL_RESERVES_MASTER_PREFIX`   | `is`                     | production `masterCachePrefix` (`is_<chain>_bn` keys) |
+   | `POOL_RESERVES_CONCURRENCY`     | `3`                      | `getPoolReserves` batches in flight per dex           |
+   | `POOL_RESERVES_BATCH_SIZE`      | `1000`                   | descriptors per batch (≤ `MAX_POOL_RESERVES_BATCH`)   |
+   | `POOL_RESERVES_INIT_TIMEOUT_MS` | `120000`                 | per-dex `initializePricing` timeout                   |
+   | `LOG_LEVEL`                     | `warn`                   | dex-lib log level on stdout                           |
+
+   Consumer tests run with `pnpm test scripts/pool-reserves-server`; set `POOL_RESERVES_TEST_REDIS_URL=redis://127.0.0.1:6399` to also run the Lua publish/write scripts against a real Redis (`publish.redis.test.ts`).
+
+   The npm script sets `TS_NODE_PREFER_TS_EXTS=true`: without it ts-node
+   resolves `./bebop/bebop` to `bebop.json` and the `Dexes` array gets an
+   undefined entry.
+
+## Endpoints
+
+A Postman collection with these requests and assertions for the invariants
+(accounting identity, well-formed rows, ≥ 90 % oracle agreement, 400/404/409
+paths) is in `pool-reserves-server.postman_collection.json`; import it and
+set `baseUrl`, `chainId`, `dexKey`. Or run it headless:
+`npx newman run scripts/pool-reserves-server/pool-reserves-server.postman_collection.json --folder "1. Discovery"`.
+
+| route                                                         | what                                                                                            |
+| ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `GET /health`                                                 | readiness per chain                                                                             |
+| `GET /dexs/:chainId`                                          | every pool-reserve dex: mode, storage, init outcome, storage size before init and now           |
+| `GET /pools/:dexKey/:chainId?cursor=&count=`                  | one HSCAN page of the storage (mode A) or of the last run's ids (mode B)                        |
+| `GET /pools/:dexKey/:chainId/:id`                             | one descriptor                                                                                  |
+| `GET /reserves/:dexKey/:chainId?cursor=&count=`               | last published run: `meta` (consumer report), `harness` (RPC counters, captured warnings), rows |
+| `GET /reserves/:dexKey/:chainId/:id`                          | one row                                                                                         |
+| `POST /generate/:chainId` / `POST /generate/:chainId/:dexKey` | run the consumer; 409 while a run is active on the chain                                        |
+| `GET /status/:chainId`                                        | init outcomes, current/last run, all reports                                                    |
+| `GET /verify/:dexKey/:chainId?sample=50`                      | on-chain oracle check (below)                                                                   |
+
+## Reading a report
+
+`meta` is the consumer's own `CollectStats`; the harness adds `rpc`,
+`warnings` and `poolsInStorageBeforeInit`.
+
+- `scannedFields = requested + unparsable`; `requested = returned + invalid + skipped + duplicateFields`.
+  Anything else is a consumer bug.
+- `skipped`: descriptors the dex did not answer for. For UniswapV2-family
+  storages most of these are pairs the factory reported as non-existent
+  (`checkExistenceAfter` without `exchange`), which the dex drops without
+  RPC. Look them up with `/pools/:dexKey/:chainId/:id`.
+- `unexpectedId`: rows whose id was not requested — dropped, never
+  persisted. `invalid`: rows violating the `PoolReserves` contract.
+- `failedBatches`: `getPoolReserves` rejected (dex-lib logs and returns `[]`
+  on its own failures, so this is rare; the swallowed ones show up in
+  `warnings`, which dex-lib's log output is the only source of).
+- `status: 'failed'`: the run built a request dex-lib refused
+  (`PoolReservesRequestError`) or Redis writes failed; the previous
+  published result is untouched and the report is under `…:lastFailure`.
+- `rpc.jsonRpcRequests` counts network requests made through the helper's
+  ethers and web3 providers during this dex's run; `multicallSubCalls` the
+  calls inside them. Background timers of other dexes can add to a window.
+- `poolsInStorageBeforeInit` vs `poolsInStorage`: PoolsWriter dexes
+  (Ekubo, Maverick, Algebra, AlgebraIntegral) publish on slaves too, so a
+  storage that was empty in the dump fills up locally. Only the pre-init
+  number is production input.
+
+## Verification oracles (`/verify`)
+
+- UniswapV2 family: `getReserves()` on the pair at the run block; a mismatch
+  is re-read at latest (a swap in between).
+- Token-pool dexes (Maverick, Algebra families): `balanceOf(pool)` per token
+  at the run block, then at the pool's state block (`getStateBlockNumber()`
+  of the in-memory pool — state-path values are exact there), then latest.
+- EkuboV3: published ids must equal the pool manager's valid pools; TVL is
+  virtual and has no balance oracle.
+- Directional / unlimited rows (mode B): no generic oracle, reported as
+  `unverified` with the reason.
+
+Run `/verify` right after `/generate`: dexes that refresh state on a timer
+(MaverickV2) move their state block past the run block within seconds, after
+which stored values legitimately lag the chain. An empty mode-B result is
+not automatically wrong: Aave GSMs that are seized or frozen are omitted by
+specification (both Mainnet GSMs were seized at the time of the first run).
+
+## Porting `consumer/` to the production service
+
+- Implement `ConsumerRedis` over your client (see `toConsumerRedis` in
+  `server/redis-cache.ts` for the ioredis one: `hlen`, `hscan`, `hset`,
+  `expire`, `del`, `transaction` — MULTI/EXEC of raw commands — and `eval`, used for the write and publish scripts so a vanished staging hash aborts the run and RENAME + PERSIST + meta are atomic). Keys of one dex/chain share a hash tag, so a Cluster client works without extra slot handling.
+- Bind `getReserves` to `POST /pool-reserves { dexKey, pools }` and pass
+  `isRequestError` for the 400 response.
+- Call `collectReserves` per dex, sequentially per chain; `concurrency`
+  bounds in-flight batches. Memory is O(batchSize × concurrency).
+- Keep the dex-lib logs: RPC failures inside `getPoolReserves` are not
+  visible in the consumer's return values.

--- a/scripts/pool-reserves-server/consumer/collect.test.ts
+++ b/scripts/pool-reserves-server/consumer/collect.test.ts
@@ -1,0 +1,523 @@
+import {
+  PoolReserves,
+  PoolsStorage,
+  PoolsStorageType,
+} from '../../../src/types';
+import { UNLIMITED_RESERVES } from '../../../src/constants';
+import { collectReserves } from './collect';
+import { FakeRedis } from './fake-redis';
+import { reservesKeys } from './keys';
+import { GetReserves } from './types';
+
+const DEX = 'testdex';
+const CHAIN = 1;
+const KEYS = reservesKeys(DEX, CHAIN);
+const STORAGE: PoolsStorage = {
+  key: 'dl_1_testdex_pools',
+  type: PoolsStorageType.RedisHash,
+  fieldInValue: true,
+};
+
+const T0 = '0x' + '1'.repeat(40);
+const T1 = '0x' + '2'.repeat(40);
+
+const row = (id: string, extra: Partial<PoolReserves> = {}): PoolReserves => ({
+  dex: DEX,
+  id,
+  address: '0x' + Buffer.from(id).toString('hex').padStart(40, '0').slice(-40),
+  reserves: { [T0]: '10', [T1]: '20' },
+  ...extra,
+});
+
+// descriptor == field == id, like the token-pools storages
+const fill = async (redis: FakeRedis, n: number) => {
+  const flat: string[] = [];
+  for (let i = 0; i < n; i++) flat.push(`p${i}`, `p${i}`);
+  await redis.hset(STORAGE.key, flat);
+};
+
+const echo: GetReserves = async (_dex, pools) => pools!.map(p => row(p));
+
+class RequestError extends Error {}
+
+const run = (
+  redis: FakeRedis,
+  getReserves: GetReserves,
+  overrides: Partial<Parameters<typeof collectReserves>[0]> = {},
+) =>
+  collectReserves({
+    dexKey: DEX,
+    chainId: CHAIN,
+    storage: STORAGE,
+    getReserves,
+    redis,
+    blockNumber: 123,
+    isRequestError: e => e instanceof RequestError,
+    ...overrides,
+  });
+
+describe('reservesKeys', () => {
+  it('puts every key of a dex/chain pair in one cluster slot', () => {
+    expect(KEYS.target).toEqual('dexlib:pools_reserves_legacy:{testdex:1}');
+    expect(KEYS.meta).toEqual('dexlib:pools_reserves_legacy:{testdex:1}:meta');
+    expect(KEYS.tmp('r')).toEqual(
+      'dexlib:pools_reserves_legacy:{testdex:1}:tmp:r',
+    );
+    expect(KEYS.lastFailure).toEqual(
+      'dexlib:pools_reserves_legacy:{testdex:1}:lastFailure',
+    );
+  });
+});
+
+describe('collectReserves (storage mode)', () => {
+  it('sweeps, persists and publishes with a full reconciliation', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 2500);
+
+    const stats = await run(redis, echo, { batchSize: 1000 });
+
+    expect(stats.status).toEqual('ok');
+    expect(stats.poolsInStorage).toEqual(2500);
+    expect(stats.scannedFields).toEqual(2500);
+    expect(stats.requested).toEqual(2500);
+    expect(stats.returned).toEqual(2500);
+    expect(stats.skipped).toEqual(0);
+    expect(stats.batches).toEqual(3);
+    expect(stats.persistedRows).toEqual(2500);
+    expect(redis.hashes.get(KEYS.target)!.size).toEqual(2500);
+    expect(redis.hashes.has(KEYS.tmp(stats.runId))).toBeFalsy();
+
+    const stored = JSON.parse(redis.hashes.get(KEYS.target)!.get('p7')!);
+    expect(stored).toMatchObject({
+      address: row('p7').address,
+      reserves: { [T0]: '10', [T1]: '20' },
+      blockNumber: 123,
+    });
+    expect(typeof stored.updatedAt).toEqual('number');
+    expect(JSON.parse(redis.strings.get(KEYS.meta)!)).toMatchObject({
+      dexKey: DEX,
+      runId: stats.runId,
+      returned: 2500,
+    });
+  });
+
+  it('never holds more than `concurrency` batches in flight', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 50);
+    let inFlight = 0;
+    let peak = 0;
+    const slow: GetReserves = async (_d, pools) => {
+      inFlight++;
+      peak = Math.max(peak, inFlight);
+      await new Promise(r => setTimeout(r, 5));
+      inFlight--;
+      return pools!.map(p => row(p));
+    };
+
+    const stats = await run(redis, slow, { batchSize: 5, concurrency: 2 });
+    expect(stats.batches).toEqual(10);
+    expect(peak).toEqual(2);
+    expect(stats.returned).toEqual(50);
+  });
+
+  it('accounts skipped, duplicate, unexpected and invalid rows per batch', async () => {
+    const redis = new FakeRedis();
+    redis.scriptedPages.set(STORAGE.key, [
+      ['0', ['a', 'a', 'b', 'b', 'c', 'c', 'b', 'b', 'd', 'd']],
+    ]);
+    const getReserves: GetReserves = async () => [
+      row('a'),
+      row('a'), // duplicate row
+      row('zzz'), // not requested
+      row('c', { address: 'not-an-address' }), // invalid
+      // b skipped, d skipped
+    ];
+
+    const stats = await run(redis, getReserves, { batchSize: 10 });
+
+    expect(stats.status).toEqual('ok');
+    expect(stats.scannedFields).toEqual(5);
+    expect(stats.requested).toEqual(5);
+    expect(stats.returned).toEqual(1);
+    expect(stats.invalid).toEqual(1);
+    expect(stats.skipped).toEqual(2);
+    expect(stats.duplicateFields).toEqual(1);
+    expect(stats.duplicateRows).toEqual(1);
+    expect(stats.unexpectedId).toEqual(1);
+    expect(stats.unexpectedIdSample).toEqual(['zzz']);
+    expect(stats.skippedSample).toEqual(['b', 'd']);
+    expect(stats.invalidSample[0]).toMatch(/^c: address/);
+    // identity: every requested field counted exactly once
+    expect(stats.requested).toEqual(
+      stats.returned + stats.invalid + stats.skipped! + stats.duplicateFields,
+    );
+    expect([...redis.hashes.get(KEYS.target)!.keys()]).toEqual(['a']);
+  });
+
+  it('counts zero and unlimited rows', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 3);
+    const getReserves: GetReserves = async () => [
+      row('p0', { reserves: { [T0]: '0', [T1]: '0' } }),
+      row('p1', { reserves: { [`${T0}_${T1}`]: UNLIMITED_RESERVES } }),
+      row('p2'),
+    ];
+    const stats = await run(redis, getReserves);
+    expect(stats.zeroReserveRows).toEqual(1);
+    expect(stats.unlimitedRows).toEqual(1);
+    expect(stats.returned).toEqual(3);
+  });
+
+  it('keeps going after a rejected batch and marks its fields skipped', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 30);
+    let calls = 0;
+    const flaky: GetReserves = async (_d, pools) => {
+      if (++calls === 2) throw new Error('rpc down');
+      return pools!.map(p => row(p));
+    };
+
+    const stats = await run(redis, flaky, { batchSize: 10, concurrency: 1 });
+    expect(stats.status).toEqual('ok');
+    expect(stats.failedBatches).toEqual(1);
+    expect(stats.failedBatchErrors).toEqual(['rpc down']);
+    expect(stats.returned).toEqual(20);
+    expect(stats.skipped).toEqual(10);
+    expect(stats.persistedRows).toEqual(20);
+  });
+
+  it('fails the run on a request error and keeps the previous result', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 20);
+    await redis.hset(KEYS.target, ['old', '{"kept":true}']);
+    redis.strings.set(KEYS.meta, '{"old":true}');
+    const rejecting: GetReserves = async () => {
+      throw new RequestError('batch too large');
+    };
+
+    const stats = await run(redis, rejecting, { batchSize: 10 });
+    expect(stats.status).toEqual('failed');
+    expect(stats.failure).toMatch(/request rejected: batch too large/);
+    expect([...redis.hashes.get(KEYS.target)!.keys()]).toEqual(['old']);
+    expect(redis.strings.get(KEYS.meta)).toEqual('{"old":true}');
+    expect(JSON.parse(redis.strings.get(KEYS.lastFailure)!).status).toEqual(
+      'failed',
+    );
+    expect(redis.hashes.has(KEYS.tmp(stats.runId))).toBeFalsy();
+  });
+
+  it('fails the run when persisting fails and leaves no temp key', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 20);
+    await redis.hset(KEYS.target, ['old', '{"kept":true}']);
+    redis.failNextHset = true;
+
+    const stats = await run(redis, echo, { batchSize: 10, concurrency: 1 });
+    expect(stats.status).toEqual('failed');
+    expect(stats.failure).toMatch(/persist failed: hset boom/);
+    expect([...redis.hashes.get(KEYS.target)!.keys()]).toEqual(['old']);
+    expect([...redis.hashes.keys()].some(k => k.includes(':tmp:'))).toBeFalsy();
+  });
+
+  it('replaces a non-empty result with an empty one and removes obsolete ids', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 5);
+    const first = await run(redis, echo);
+    expect(first.returned).toEqual(5);
+
+    const second = await run(redis, async () => []);
+    expect(second.status).toEqual('ok');
+    expect(second.returned).toEqual(0);
+    expect(second.skipped).toEqual(5);
+    expect(redis.hashes.has(KEYS.target)).toBeFalsy();
+    expect(JSON.parse(redis.strings.get(KEYS.meta)!).runId).toEqual(
+      second.runId,
+    );
+  });
+
+  it('refreshes the staging TTL on every write and publishes without one', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 30);
+    const ttlSeen: number[] = [];
+    const stats = await run(redis, echo, {
+      batchSize: 10,
+      concurrency: 1,
+      onBatch: () => {
+        const tmp = [...redis.ttls.keys()].find(k => k.includes(':tmp:'))!;
+        ttlSeen.push(redis.ttls.get(tmp)!);
+        // the clock runs between batches; the next write must reset it
+        redis.ttls.set(tmp, 100);
+      },
+    });
+    expect(ttlSeen).toEqual([3600, 3600, 3600]);
+    expect(redis.ttls.has(KEYS.target)).toBeFalsy();
+    expect(redis.ttls.has(KEYS.tmp(stats.runId))).toBeFalsy();
+  });
+
+  it('fails when the staging hash disappears between writes', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 20);
+    await redis.hset(KEYS.target, ['old', '{"kept":true}']);
+    let writes = 0;
+    const stats = await run(redis, echo, {
+      batchSize: 10,
+      concurrency: 1,
+      onBatch: () => {
+        if (++writes === 1) {
+          for (const k of redis.hashes.keys())
+            if (k.includes(':tmp:')) redis.expireNow(k);
+        }
+      },
+    });
+    expect(stats.status).toEqual('failed');
+    expect(stats.failure).toMatch(/persist failed: STAGING_MISSING/);
+    expect([...redis.hashes.get(KEYS.target)!.keys()]).toEqual(['old']);
+  });
+
+  it('fails instead of publishing when the staging hash expired', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 5);
+    await redis.hset(KEYS.target, ['old', '{"kept":true}']);
+    redis.strings.set(KEYS.meta, '{"old":true}');
+    const stats = await run(redis, echo, {
+      onBatch: () => {
+        for (const k of redis.hashes.keys())
+          if (k.includes(':tmp:')) redis.expireNow(k);
+      },
+    });
+    expect(stats.status).toEqual('failed');
+    expect(stats.failure).toMatch(/STAGING_MISSING/);
+    expect([...redis.hashes.get(KEYS.target)!.keys()]).toEqual(['old']);
+    expect(redis.strings.get(KEYS.meta)).toEqual('{"old":true}');
+  });
+
+  it('records a failure when the publish transaction itself fails', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 5);
+    redis.failNextPublish = true;
+    const stats = await run(redis, echo);
+    expect(stats.status).toEqual('failed');
+    expect(stats.failure).toMatch(/publish failed.*eval boom/);
+    expect(JSON.parse(redis.strings.get(KEYS.lastFailure)!).runId).toEqual(
+      stats.runId,
+    );
+    expect([...redis.hashes.keys()].some(k => k.includes(':tmp:'))).toBeFalsy();
+  });
+
+  it('drains an outstanding request before finalizing when the scan fails', async () => {
+    const redis = new FakeRedis();
+    redis.scriptedPages.set(STORAGE.key, [
+      ['1', ['a', 'a']],
+      ['ERR', []], // reached by the second worker while the first holds `a`
+    ]);
+    let released!: () => void;
+    const gate = new Promise<void>(r => (released = r));
+    let outstandingAtFault = -1;
+    let outstanding = 0;
+    let finished = 0;
+    const slow: GetReserves = async (_d, pools) => {
+      outstanding++;
+      await gate;
+      outstanding--;
+      finished++;
+      return pools!.map(p => row(p));
+    };
+    const pending = run(redis, slow, {
+      batchSize: 1,
+      concurrency: 2,
+      onBatch: () => {
+        outstandingAtFault = outstanding;
+      },
+    });
+    // let both workers advance: one is inside getReserves, the other hit ERR
+    await new Promise(r => setTimeout(r, 20));
+    expect(outstanding).toEqual(1);
+    released();
+    const stats = await pending;
+    expect(stats.status).toEqual('failed');
+    expect(stats.failure).toMatch(/scan failed/);
+    expect(finished).toEqual(1);
+    expect(stats.batches).toEqual(1);
+    expect(outstandingAtFault).toEqual(0);
+    expect([...redis.hashes.keys()].some(k => k.includes(':tmp:'))).toBeFalsy();
+  });
+
+  it('turns a throwing onBatch callback into a failed run, not an unhandled rejection', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 3);
+    const stats = await run(redis, echo, {
+      batchSize: 1,
+      onBatch: () => {
+        throw new Error('callback boom');
+      },
+    });
+    expect(stats.status).toEqual('failed');
+    expect(stats.failure).toMatch(/batch failed: callback boom/);
+  });
+
+  it('awaits an async onBatch callback and fails the run when it rejects', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 3);
+    const unhandled: unknown[] = [];
+    const listener = (e: unknown) => unhandled.push(e);
+    process.on('unhandledRejection', listener);
+    try {
+      const stats = await run(redis, echo, {
+        batchSize: 1,
+        onBatch: async () => {
+          await new Promise(r => setTimeout(r, 1));
+          throw new Error('async callback boom');
+        },
+      });
+      await new Promise(r => setTimeout(r, 5));
+      expect(stats.status).toEqual('failed');
+      expect(stats.failure).toMatch(/batch failed: async callback boom/);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', listener);
+    }
+  });
+
+  it('records a failure when the final staging count fails', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 3);
+    await redis.hset(KEYS.target, ['old', '{"kept":true}']);
+    let hlenCalls = 0;
+    const original = redis.hlen.bind(redis);
+    redis.hlen = async key => {
+      // first call is the storage HLEN, second the staging count
+      if (++hlenCalls === 2) throw new Error('hlen boom');
+      return original(key);
+    };
+    const stats = await run(redis, echo);
+    expect(stats.status).toEqual('failed');
+    expect(stats.failure).toMatch(/publish failed.*hlen boom/);
+    expect([...redis.hashes.get(KEYS.target)!.keys()]).toEqual(['old']);
+    expect(redis.strings.has(KEYS.lastFailure)).toBeTruthy();
+  });
+
+  it('stops pulling batches once a fatal error is set', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 50);
+    let calls = 0;
+    const rejecting: GetReserves = async () => {
+      calls++;
+      throw new RequestError('bad request');
+    };
+    const stats = await run(redis, rejecting, { batchSize: 5, concurrency: 2 });
+    expect(stats.status).toEqual('failed');
+    expect(calls).toBeLessThanOrEqual(2);
+  });
+
+  it('counts a field returned in two different batches once in the hash', async () => {
+    const redis = new FakeRedis();
+    redis.scriptedPages.set(STORAGE.key, [
+      ['0', ['a', 'a', 'b', 'b', 'a', 'a']],
+    ]);
+    const stats = await run(redis, echo, { batchSize: 2, concurrency: 1 });
+    expect(stats.batches).toEqual(2);
+    expect(stats.returned).toEqual(3);
+    expect(stats.persistedRows).toEqual(2);
+    expect(stats.duplicateFields).toEqual(0);
+  });
+
+  it('counts a null row as invalid instead of throwing', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 2);
+    const stats = await run(redis, async () => [
+      null as unknown as PoolReserves,
+      row('p1'),
+    ]);
+    expect(stats.status).toEqual('ok');
+    expect(stats.invalid).toEqual(0);
+    expect(stats.unexpectedId).toEqual(1);
+    expect(stats.returned).toEqual(1);
+  });
+
+  it('counts a non-array response as a failed batch, keeping the accounting identity', async () => {
+    const redis = new FakeRedis();
+    await fill(redis, 4);
+    const stats = await run(
+      redis,
+      async () => null as unknown as PoolReserves[],
+      { batchSize: 2, concurrency: 1 },
+    );
+    expect(stats.status).toEqual('ok');
+    expect(stats.failedBatches).toEqual(2);
+    expect(stats.failedBatchErrors).toEqual([
+      'response is not an array',
+      'response is not an array',
+    ]);
+    expect(stats.invalid).toEqual(0);
+    expect(stats.requested).toEqual(
+      stats.returned + stats.invalid + stats.skipped! + stats.duplicateFields,
+    );
+  });
+
+  it('rejects non-integer or out-of-range parameters up front', async () => {
+    const r = new FakeRedis();
+    await expect(run(r, echo, { batchSize: 1001 })).rejects.toThrow(
+      /batchSize/,
+    );
+    await expect(run(r, echo, { batchSize: 1.5 })).rejects.toThrow(/batchSize/);
+    await expect(run(r, echo, { batchSize: NaN })).rejects.toThrow(/batchSize/);
+    await expect(run(r, echo, { concurrency: 0 })).rejects.toThrow(
+      /concurrency/,
+    );
+    await expect(run(r, echo, { concurrency: Infinity })).rejects.toThrow(
+      /concurrency/,
+    );
+  });
+});
+
+describe('collectReserves (enumerated mode)', () => {
+  it('calls without pools and reports requested/skipped as n/a', async () => {
+    const redis = new FakeRedis();
+    const getReserves = jest.fn(async () => [row('x'), row('y')]);
+
+    const stats = await run(redis, getReserves, { storage: null });
+    expect(getReserves).toHaveBeenCalledWith(DEX);
+    expect(stats.mode).toEqual('enumerated');
+    expect(stats.requested).toBeNull();
+    expect(stats.skipped).toBeNull();
+    expect(stats.returned).toEqual(2);
+    expect(stats.batches).toEqual(1);
+    expect(redis.hashes.get(KEYS.target)!.size).toEqual(2);
+  });
+
+  it('publishes an empty result when the dex returns nothing', async () => {
+    const redis = new FakeRedis();
+    const stats = await run(redis, async () => [], { storage: null });
+    expect(stats.status).toEqual('ok');
+    expect(redis.hashes.has(KEYS.target)).toBeFalsy();
+    expect(redis.strings.has(KEYS.meta)).toBeTruthy();
+  });
+
+  it('counts a null row as invalid in enumerated mode', async () => {
+    const redis = new FakeRedis();
+    const stats = await run(
+      redis,
+      async () => [null as unknown as PoolReserves, row('x')],
+      {
+        storage: null,
+      },
+    );
+    expect(stats.invalid).toEqual(1);
+    expect(stats.invalidSample[0]).toMatch(/row is null/);
+    expect(stats.returned).toEqual(1);
+  });
+
+  it('marks a dex failure as a failed batch, not a failed run', async () => {
+    const redis = new FakeRedis();
+    const stats = await run(
+      redis,
+      async () => {
+        throw new Error('boom');
+      },
+      { storage: null },
+    );
+    expect(stats.status).toEqual('ok');
+    expect(stats.failedBatches).toEqual(1);
+    expect(stats.returned).toEqual(0);
+  });
+});

--- a/scripts/pool-reserves-server/consumer/collect.ts
+++ b/scripts/pool-reserves-server/consumer/collect.ts
@@ -1,0 +1,290 @@
+import { PoolReserves } from '../../../src/types';
+import { MAX_POOL_RESERVES_BATCH } from '../../../src/constants';
+import {
+  Batch,
+  CollectParams,
+  CollectStats,
+  StoredReserves,
+  SweepCounters,
+} from './types';
+import { newRunId, reservesKeys } from './keys';
+import { sweepStorage } from './sweep';
+import { RunSink } from './publish';
+import { hasUnlimited, isZeroReserves, validateRow } from './validate';
+
+const SAMPLE_LIMIT = 50;
+const DEFAULT_CONCURRENCY = 3;
+
+const errorMessage = (e: unknown): string =>
+  e instanceof Error ? e.message : String(e);
+
+const pushSample = (sample: string[], value: string) => {
+  if (sample.length < SAMPLE_LIMIT) sample.push(value);
+};
+
+const isPositiveInteger = (n: number, max = Number.MAX_SAFE_INTEGER) =>
+  Number.isSafeInteger(n) && n >= 1 && n <= max;
+
+// One run of the consumer for one dex: sweep → getReserves → validate →
+// persist → publish. Memory is bounded by `concurrency` batches; nothing
+// proportional to the storage size is retained.
+export async function collectReserves(
+  params: CollectParams,
+): Promise<CollectStats> {
+  const {
+    dexKey,
+    chainId,
+    storage,
+    getReserves,
+    redis,
+    concurrency = DEFAULT_CONCURRENCY,
+    batchSize = MAX_POOL_RESERVES_BATCH,
+    blockNumber = null,
+    now = Date.now,
+    isRequestError = () => false,
+    onBatch,
+  } = params;
+
+  if (!isPositiveInteger(batchSize, MAX_POOL_RESERVES_BATCH)) {
+    throw new Error(
+      `batchSize must be an integer within 1..${MAX_POOL_RESERVES_BATCH}`,
+    );
+  }
+  if (!isPositiveInteger(concurrency)) {
+    throw new Error('concurrency must be a positive integer');
+  }
+
+  const keys = reservesKeys(dexKey, chainId, params.keyPrefix);
+  const startedAt = now();
+  const runId = newRunId(startedAt);
+  const sink = new RunSink(redis, keys, runId);
+
+  const stats: CollectStats = {
+    dexKey,
+    chainId,
+    mode: storage ? 'storage' : 'enumerated',
+    storageKey: storage?.key ?? null,
+    fieldInValue: storage?.fieldInValue ?? null,
+    runId,
+    startedAt,
+    finishedAt: startedAt,
+    durationMs: 0,
+    blockNumber,
+    concurrency,
+    batchSize,
+    poolsInStorage: null,
+    scannedFields: 0,
+    unparsable: 0,
+    requested: storage ? 0 : null,
+    returned: 0,
+    skipped: storage ? 0 : null,
+    duplicateFields: 0,
+    duplicateRows: 0,
+    unexpectedId: 0,
+    invalid: 0,
+    failedBatches: 0,
+    batches: 0,
+    persistedRows: 0,
+    skippedSample: [],
+    unexpectedIdSample: [],
+    invalidSample: [],
+    failedBatchErrors: [],
+    zeroReserveRows: 0,
+    unlimitedRows: 0,
+    status: 'ok',
+  };
+
+  // first fatal condition wins; workers stop pulling once it is set
+  let fatal: string | undefined;
+  const fail = (message: string) => {
+    if (fatal === undefined) fatal = message;
+  };
+
+  const persist = async (rows: PoolReserves[]) => {
+    const updatedAt = now();
+    const fieldValues: string[] = [];
+    for (const row of rows) {
+      const stored: StoredReserves = {
+        address: row.address,
+        reserves: row.reserves,
+        updatedAt,
+        blockNumber,
+      };
+      fieldValues.push(row.id, JSON.stringify(stored));
+    }
+    await sink.write(fieldValues);
+  };
+
+  // Reconciles one response against the fields it was asked for (mode A) or
+  // against itself (mode B). Every requested field ends up counted exactly
+  // once: returned, invalid, skipped or duplicateFields.
+  const reconcile = (fields: string[] | null, rows: unknown[]) => {
+    const wanted = fields ? new Set(fields) : null;
+    const received = new Set<string>();
+    const accepted: PoolReserves[] = [];
+
+    for (const candidate of rows) {
+      const id = (candidate as Partial<PoolReserves> | null)?.id;
+      if (wanted && (typeof id !== 'string' || !wanted.has(id))) {
+        stats.unexpectedId++;
+        pushSample(stats.unexpectedIdSample, String(id));
+        continue;
+      }
+      if (typeof id === 'string' && received.has(id)) {
+        stats.duplicateRows++;
+        continue;
+      }
+
+      const problem = validateRow(candidate, dexKey);
+      if (problem) {
+        stats.invalid++;
+        pushSample(stats.invalidSample, `${String(id)}: ${problem}`);
+        if (typeof id === 'string') received.add(id);
+        continue;
+      }
+      const row = candidate as PoolReserves;
+      received.add(row.id);
+      stats.returned++;
+      if (isZeroReserves(row.reserves)) stats.zeroReserveRows++;
+      if (hasUnlimited(row.reserves)) stats.unlimitedRows++;
+      accepted.push(row);
+    }
+
+    if (fields) {
+      const counted = new Set<string>();
+      for (const field of fields) {
+        if (counted.has(field)) {
+          stats.duplicateFields++;
+          continue;
+        }
+        counted.add(field);
+        if (!received.has(field)) {
+          stats.skipped!++;
+          pushSample(stats.skippedSample, field);
+        }
+      }
+    }
+    return accepted;
+  };
+
+  // Never rejects: every failure is either a failed batch (the run goes on)
+  // or a fatal condition.
+  const processBatch = async (batch: Batch | null) => {
+    try {
+      stats.batches++;
+      if (batch) stats.requested! += batch.fields.length;
+      let response: unknown;
+      try {
+        response = batch
+          ? await getReserves(dexKey, batch.descriptors)
+          : await getReserves(dexKey);
+      } catch (e) {
+        if (isRequestError(e))
+          return fail(`request rejected: ${errorMessage(e)}`);
+        stats.failedBatches++;
+        pushSample(stats.failedBatchErrors, errorMessage(e));
+        if (batch) {
+          stats.skipped! += batch.fields.length;
+          for (const field of batch.fields)
+            pushSample(stats.skippedSample, field);
+        }
+        return;
+      }
+      if (!Array.isArray(response)) {
+        // a malformed response is a failed batch, so the accounting identity
+        // requested = returned + invalid + skipped + duplicateFields holds
+        stats.failedBatches++;
+        pushSample(stats.failedBatchErrors, 'response is not an array');
+        if (batch) {
+          stats.skipped! += batch.fields.length;
+          for (const field of batch.fields)
+            pushSample(stats.skippedSample, field);
+        }
+        return;
+      }
+      const accepted = reconcile(batch ? batch.fields : null, response);
+      try {
+        await persist(accepted);
+      } catch (e) {
+        return fail(`persist failed: ${errorMessage(e)}`);
+      }
+      await onBatch?.(stats);
+    } catch (e) {
+      fail(`batch failed: ${errorMessage(e)}`);
+    }
+  };
+
+  if (!storage) {
+    await processBatch(null);
+  } else {
+    try {
+      stats.poolsInStorage = await redis.hlen(storage.key);
+    } catch (e) {
+      fail(`hlen failed: ${errorMessage(e)}`);
+    }
+    const counters: SweepCounters = {
+      scannedFields: 0,
+      unparsable: 0,
+      pages: 0,
+    };
+    const iterator = sweepStorage(
+      redis,
+      storage.key,
+      storage.fieldInValue,
+      batchSize,
+      counters,
+    )[Symbol.asyncIterator]();
+
+    // Fixed worker pool over one shared iterator: async generators serialize
+    // concurrent next() calls, so the scan advances only when a worker is
+    // free and Redis reads are paced by RPC throughput. Every worker settles
+    // before the run is finalized, so no batch can land after the report.
+    const worker = async () => {
+      while (fatal === undefined) {
+        let step: IteratorResult<Batch>;
+        try {
+          step = await iterator.next();
+        } catch (e) {
+          return fail(`scan failed: ${errorMessage(e)}`);
+        }
+        if (step.done) return;
+        await processBatch(step.value);
+      }
+    };
+    await Promise.all(Array.from({ length: concurrency }, worker));
+    stats.scannedFields = counters.scannedFields;
+    stats.unparsable = counters.unparsable;
+  }
+
+  const finish = () => {
+    stats.finishedAt = now();
+    stats.durationMs = stats.finishedAt - stats.startedAt;
+  };
+
+  if (fatal === undefined) {
+    try {
+      stats.persistedRows = await sink.count();
+      finish();
+      await sink.publish(keys, JSON.stringify(stats));
+      return stats;
+    } catch (e) {
+      // a lost EXEC acknowledgement is indistinguishable from a failed one:
+      // the publication may have happened, the discard below is then a no-op
+      fail(
+        `publish failed (result may or may not be published): ${errorMessage(
+          e,
+        )}`,
+      );
+    }
+  }
+
+  finish();
+  stats.status = 'failed';
+  stats.failure = fatal;
+  try {
+    await sink.discard(keys, JSON.stringify(stats));
+  } catch (e) {
+    stats.failure += `; discard failed: ${errorMessage(e)}`;
+  }
+  return stats;
+}

--- a/scripts/pool-reserves-server/consumer/fake-redis.ts
+++ b/scripts/pool-reserves-server/consumer/fake-redis.ts
@@ -1,0 +1,184 @@
+import { ConsumerRedis } from './types';
+import { PUBLISH_SCRIPT, WRITE_SCRIPT } from './publish';
+
+// In-memory ConsumerRedis for tests. Mirrors the Redis semantics the
+// consumer relies on: TTLs travel with RENAME and are cleared by PERSIST,
+// MULTI keeps executing after a command error and reports the first one at
+// the end, EVAL of the publish script is interpreted natively. HSCAN pages
+// can be scripted per key to reproduce oversized, empty and duplicate pages.
+export class FakeRedis implements ConsumerRedis {
+  hashes = new Map<string, Map<string, string>>();
+  strings = new Map<string, string>();
+  // remaining TTL in seconds; absent = persistent
+  ttls = new Map<string, number>();
+  scriptedPages = new Map<string, [string, string[]][]>();
+  commands: string[][] = [];
+  failNextHset = false;
+  failNextPublish = false;
+  failNextHlen = false;
+
+  // simulate the clock running out on a key
+  expireNow(key: string) {
+    if (this.ttls.has(key)) {
+      this.ttls.delete(key);
+      this.hashes.delete(key);
+      this.strings.delete(key);
+    }
+  }
+
+  async hlen(key: string): Promise<number> {
+    if (this.failNextHlen) {
+      this.failNextHlen = false;
+      throw new Error('hlen boom');
+    }
+    return this.hashes.get(key)?.size ?? 0;
+  }
+
+  async hscan(
+    key: string,
+    cursor: string,
+    count: number,
+  ): Promise<[string, string[]]> {
+    const scripted = this.scriptedPages.get(key);
+    if (scripted) {
+      const index = Number(cursor);
+      // a page labelled 'ERR' makes the scan itself fail
+      if (scripted[index][0] === 'ERR') throw new Error('hscan boom');
+      const [, flat] = scripted[index];
+      const next = index + 1 < scripted.length ? String(index + 1) : '0';
+      return [next, flat];
+    }
+    const entries = [...(this.hashes.get(key) ?? new Map()).entries()];
+    const start = Number(cursor);
+    const end = Math.min(start + count, entries.length);
+    const flat: string[] = [];
+    for (const [f, v] of entries.slice(start, end)) flat.push(f, v);
+    return [end >= entries.length ? '0' : String(end), flat];
+  }
+
+  async hset(key: string, fieldValues: string[]): Promise<void> {
+    if (this.failNextHset) {
+      this.failNextHset = false;
+      throw new Error('hset boom');
+    }
+    let hash = this.hashes.get(key);
+    if (!hash) {
+      hash = new Map();
+      this.hashes.set(key, hash);
+    }
+    for (let i = 0; i + 1 < fieldValues.length; i += 2) {
+      hash.set(fieldValues[i], fieldValues[i + 1]);
+    }
+  }
+
+  async expire(key: string, seconds: number): Promise<void> {
+    if (this.hashes.has(key) || this.strings.has(key))
+      this.ttls.set(key, seconds);
+  }
+
+  async del(keys: string[]): Promise<void> {
+    for (const key of keys) {
+      this.hashes.delete(key);
+      this.strings.delete(key);
+      this.ttls.delete(key);
+    }
+  }
+
+  private run(cmd: string, args: string[]) {
+    switch (cmd.toUpperCase()) {
+      case 'RENAME': {
+        const [from, to] = args;
+        const hash = this.hashes.get(from);
+        if (!hash) throw new Error('ERR no such key');
+        this.hashes.delete(from);
+        this.hashes.set(to, hash);
+        const ttl = this.ttls.get(from);
+        this.ttls.delete(from);
+        if (ttl !== undefined) this.ttls.set(to, ttl);
+        else this.ttls.delete(to);
+        return 'OK';
+      }
+      case 'PERSIST':
+        return this.ttls.delete(args[0]) ? 1 : 0;
+      case 'SET':
+        this.strings.set(args[0], args[1]);
+        this.ttls.delete(args[0]);
+        return 'OK';
+      case 'DEL': {
+        let n = 0;
+        for (const k of args) {
+          if (this.hashes.delete(k) || this.strings.delete(k)) n++;
+          this.ttls.delete(k);
+        }
+        return n;
+      }
+      case 'HSET': {
+        const [key, ...fv] = args;
+        if (this.failNextHset) {
+          this.failNextHset = false;
+          throw new Error('hset boom');
+        }
+        let hash = this.hashes.get(key);
+        if (!hash) {
+          hash = new Map();
+          this.hashes.set(key, hash);
+        }
+        for (let i = 0; i + 1 < fv.length; i += 2) hash.set(fv[i], fv[i + 1]);
+        return fv.length / 2;
+      }
+      case 'EXPIRE':
+        if (this.hashes.has(args[0]) || this.strings.has(args[0])) {
+          this.ttls.set(args[0], Number(args[1]));
+          return 1;
+        }
+        return 0;
+      case 'EXISTS':
+        return this.hashes.has(args[0]) || this.strings.has(args[0]) ? 1 : 0;
+      default:
+        throw new Error(`unsupported ${cmd}`);
+    }
+  }
+
+  async transaction(commands: string[][]): Promise<void> {
+    this.commands.push(...commands);
+    let firstError: unknown;
+    for (const [cmd, ...args] of commands) {
+      try {
+        this.run(cmd, args);
+      } catch (e) {
+        firstError = firstError ?? e;
+      }
+    }
+    if (firstError) throw firstError;
+  }
+
+  async eval(script: string, keys: string[], args: string[]): Promise<unknown> {
+    if (script === WRITE_SCRIPT) {
+      const [tmp] = keys;
+      const [ttl, mustExist, ...fieldValues] = args;
+      if (mustExist === '1' && !this.run('EXISTS', [tmp])) {
+        throw new Error('STAGING_MISSING');
+      }
+      this.run('HSET', [tmp, ...fieldValues]);
+      this.run('EXPIRE', [tmp, ttl]);
+      return 1;
+    }
+    if (script !== PUBLISH_SCRIPT) throw new Error('unknown script');
+    if (this.failNextPublish) {
+      this.failNextPublish = false;
+      throw new Error('eval boom');
+    }
+    const [tmp, target, meta, lastFailure] = keys;
+    const [metaJson, hasRows] = args;
+    if (hasRows === '1') {
+      if (!this.run('EXISTS', [tmp])) throw new Error('STAGING_MISSING');
+      this.run('RENAME', [tmp, target]);
+      this.run('PERSIST', [target]);
+    } else {
+      this.run('DEL', [target]);
+    }
+    this.run('SET', [meta, metaJson]);
+    this.run('DEL', [lastFailure]);
+    return 1;
+  }
+}

--- a/scripts/pool-reserves-server/consumer/index.ts
+++ b/scripts/pool-reserves-server/consumer/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './keys';
+export { sweepStorage, wrapDescriptor } from './sweep';
+export { collectReserves } from './collect';
+export { RunSink, TMP_TTL_SECONDS } from './publish';
+export { validateRow } from './validate';

--- a/scripts/pool-reserves-server/consumer/keys.ts
+++ b/scripts/pool-reserves-server/consumer/keys.ts
@@ -1,0 +1,29 @@
+export const DEFAULT_KEY_PREFIX = 'dexlib:pools_reserves_legacy';
+
+export type ReservesKeys = {
+  target: string;
+  meta: string;
+  lastFailure: string;
+  tmp: (runId: string) => string;
+};
+
+export function reservesKeys(
+  dexKey: string,
+  chainId: number,
+  prefix: string = DEFAULT_KEY_PREFIX,
+): ReservesKeys {
+  // `{…}` is a Redis Cluster hash tag: target, meta, staging and failure
+  // keys land in one slot, which RENAME and MULTI/EVAL across them require
+  const target = `${prefix}:{${dexKey}:${chainId}}`;
+  return {
+    target,
+    meta: `${target}:meta`,
+    lastFailure: `${target}:lastFailure`,
+    tmp: runId => `${target}:tmp:${runId}`,
+  };
+}
+
+export function newRunId(now: number = Date.now()): string {
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `${new Date(now).toISOString().replace(/[:.]/g, '-')}-${rand}`;
+}

--- a/scripts/pool-reserves-server/consumer/publish.redis.test.ts
+++ b/scripts/pool-reserves-server/consumer/publish.redis.test.ts
@@ -1,0 +1,84 @@
+// Runs the publish/write Lua scripts against a real Redis, because FakeRedis
+// interprets them by hand. Opt-in: set POOL_RESERVES_TEST_REDIS_URL.
+import Redis from 'ioredis';
+import { RunSink } from './publish';
+import { reservesKeys } from './keys';
+import { toConsumerRedis } from '../server/redis-cache';
+
+const url = process.env.POOL_RESERVES_TEST_REDIS_URL;
+const describeIf = url ? describe : describe.skip;
+
+describeIf('RunSink against a real Redis', () => {
+  const redis = new Redis(url!);
+  const prefix = `test:pool-reserves:${process.pid}`;
+  const keys = reservesKeys('dex', 1, prefix);
+  const consumer = () => toConsumerRedis(redis);
+
+  afterEach(async () => {
+    const found = await redis.keys(`${prefix}:*`);
+    if (found.length) await redis.del(...found);
+  });
+  afterAll(() => redis.quit());
+
+  it('publishes a persistent hash and refreshes the staging TTL', async () => {
+    const sink = new RunSink(consumer(), keys, 'run1');
+    await sink.write(['a', '1']);
+    expect(await redis.ttl(sink.tmpKey)).toBeGreaterThan(3500);
+    await redis.expire(sink.tmpKey, 100);
+    await sink.write(['b', '2']);
+    expect(await redis.ttl(sink.tmpKey)).toBeGreaterThan(3500);
+
+    await sink.publish(keys, '{"meta":1}');
+    expect(await redis.ttl(keys.target)).toEqual(-1);
+    expect(await redis.hgetall(keys.target)).toEqual({ a: '1', b: '2' });
+    expect(await redis.get(keys.meta)).toEqual('{"meta":1}');
+    expect(await redis.exists(sink.tmpKey)).toEqual(0);
+  });
+
+  it('refuses to write into a staging hash that disappeared', async () => {
+    const sink = new RunSink(consumer(), keys, 'run2');
+    await sink.write(['a', '1']);
+    await redis.del(sink.tmpKey);
+    await expect(sink.write(['b', '2'])).rejects.toThrow(/STAGING_MISSING/);
+    expect(await redis.exists(sink.tmpKey)).toEqual(0);
+  });
+
+  it('refuses to publish when the staging hash is missing and leaves meta alone', async () => {
+    await redis.hset(keys.target, 'old', '1');
+    await redis.set(keys.meta, 'old-meta');
+    const sink = new RunSink(consumer(), keys, 'run3');
+    await sink.write(['a', '1']);
+    await redis.del(sink.tmpKey);
+    await expect(sink.publish(keys, 'new-meta')).rejects.toThrow(
+      /STAGING_MISSING/,
+    );
+    expect(await redis.hgetall(keys.target)).toEqual({ old: '1' });
+    expect(await redis.get(keys.meta)).toEqual('old-meta');
+  });
+
+  it('publishes an empty run by deleting the target', async () => {
+    await redis.hset(keys.target, 'old', '1');
+    await redis.set(keys.lastFailure, 'x');
+    const sink = new RunSink(consumer(), keys, 'run4');
+    await sink.publish(keys, 'empty-meta');
+    expect(await redis.exists(keys.target)).toEqual(0);
+    expect(await redis.get(keys.meta)).toEqual('empty-meta');
+    expect(await redis.exists(keys.lastFailure)).toEqual(0);
+  });
+
+  it('discard removes staging and records the failure', async () => {
+    const sink = new RunSink(consumer(), keys, 'run5');
+    await sink.write(['a', '1']);
+    await sink.discard(keys, 'failure-meta');
+    expect(await redis.exists(sink.tmpKey)).toEqual(0);
+    expect(await redis.get(keys.lastFailure)).toEqual('failure-meta');
+  });
+
+  it('handles a full 1000-row batch in one script call', async () => {
+    const sink = new RunSink(consumer(), keys, 'run6');
+    const fv: string[] = [];
+    for (let i = 0; i < 1000; i++) fv.push(`f${i}`, `{"v":${i}}`);
+    await sink.write(fv);
+    expect(await redis.hlen(sink.tmpKey)).toEqual(1000);
+  });
+});

--- a/scripts/pool-reserves-server/consumer/publish.ts
+++ b/scripts/pool-reserves-server/consumer/publish.ts
@@ -1,0 +1,91 @@
+import { ConsumerRedis } from './types';
+import { ReservesKeys } from './keys';
+
+export const TMP_TTL_SECONDS = 3600;
+
+// KEYS: tmp, target, meta, lastFailure. ARGV: meta json, '1' when rows exist.
+// RENAME carries the staging TTL over, hence PERSIST. A missing staging hash
+// (expired, deleted) aborts before anything else is written; MULTI could not
+// give that guarantee because it does not roll back command errors.
+export const PUBLISH_SCRIPT = `
+if ARGV[2] == '1' then
+  if redis.call('EXISTS', KEYS[1]) == 0 then
+    return redis.error_reply('STAGING_MISSING')
+  end
+  redis.call('RENAME', KEYS[1], KEYS[2])
+  redis.call('PERSIST', KEYS[2])
+else
+  redis.call('DEL', KEYS[2])
+end
+redis.call('SET', KEYS[3], ARGV[1])
+redis.call('DEL', KEYS[4])
+return 1
+`;
+
+// KEYS: tmp. ARGV: ttl seconds, '1' when the staging hash must already exist
+// (every write after the first), then field/value pairs. A staging hash that
+// expired or was evicted between writes must fail the run instead of being
+// silently recreated with only the later batches.
+export const WRITE_SCRIPT = `
+if ARGV[2] == '1' and redis.call('EXISTS', KEYS[1]) == 0 then
+  return redis.error_reply('STAGING_MISSING')
+end
+redis.call('HSET', KEYS[1], unpack(ARGV, 3))
+redis.call('EXPIRE', KEYS[1], ARGV[1])
+return 1
+`;
+
+// Buffers rows for one run in a temp hash so readers never see a partial
+// result. Each batch is one guarded HSET plus an EXPIRE refresh in one round
+// trip, so an interrupted run leaves nothing behind for longer than the TTL
+// and a live run never lets its staging hash expire unnoticed.
+export class RunSink {
+  private touched = false;
+  readonly tmpKey: string;
+
+  constructor(
+    private readonly redis: ConsumerRedis,
+    keys: ReservesKeys,
+    runId: string,
+  ) {
+    this.tmpKey = keys.tmp(runId);
+  }
+
+  async write(fieldValues: string[]): Promise<void> {
+    if (fieldValues.length === 0) return;
+    await this.redis.eval(
+      WRITE_SCRIPT,
+      [this.tmpKey],
+      [String(TMP_TTL_SECONDS), this.touched ? '1' : '0', ...fieldValues],
+    );
+    this.touched = true;
+  }
+
+  get hasRows(): boolean {
+    return this.touched;
+  }
+
+  async count(): Promise<number> {
+    return this.touched ? this.redis.hlen(this.tmpKey) : 0;
+  }
+
+  // Swaps the temp hash into place together with its metadata. An empty run
+  // is legitimate (empty inventory, every mode-B pool disabled): the target
+  // is removed and the metadata says so, which `/reserves` distinguishes
+  // from "never run".
+  async publish(keys: ReservesKeys, meta: string): Promise<void> {
+    await this.redis.eval(
+      PUBLISH_SCRIPT,
+      [this.tmpKey, keys.target, keys.meta, keys.lastFailure],
+      [meta, this.touched ? '1' : '0'],
+    );
+  }
+
+  // Leaves the previously published result untouched.
+  async discard(keys: ReservesKeys, failureMeta: string): Promise<void> {
+    await this.redis.transaction([
+      ['DEL', this.tmpKey],
+      ['SET', keys.lastFailure, failureMeta],
+    ]);
+  }
+}

--- a/scripts/pool-reserves-server/consumer/sweep.test.ts
+++ b/scripts/pool-reserves-server/consumer/sweep.test.ts
@@ -1,0 +1,118 @@
+import { sweepStorage, wrapDescriptor } from './sweep';
+import { FakeRedis } from './fake-redis';
+import { Batch, SweepCounters } from './types';
+
+const KEY = 'dl_1_test_pools';
+
+const collect = async (
+  redis: FakeRedis,
+  fieldInValue: boolean,
+  batchSize: number,
+) => {
+  const counters: SweepCounters = { scannedFields: 0, unparsable: 0, pages: 0 };
+  const batches: Batch[] = [];
+  for await (const b of sweepStorage(
+    redis,
+    KEY,
+    fieldInValue,
+    batchSize,
+    counters,
+  )) {
+    batches.push(b);
+  }
+  return { counters, batches };
+};
+
+describe('wrapDescriptor', () => {
+  it('prepends the field to a JSON object without parsing it', () => {
+    expect(wrapDescriptor('7', '{"a":"0x1","t0":"0x2"}')).toEqual(
+      '{"i":"7","a":"0x1","t0":"0x2"}',
+    );
+    expect(JSON.parse(wrapDescriptor('7', ' {"a":1} ')!)).toEqual({
+      i: '7',
+      a: 1,
+    });
+  });
+
+  it('handles the empty object', () => {
+    expect(JSON.parse(wrapDescriptor('x', '{}')!)).toEqual({ i: 'x' });
+    expect(JSON.parse(wrapDescriptor('x', '{ }')!)).toEqual({ i: 'x' });
+  });
+
+  it('rejects values that are not objects', () => {
+    expect(wrapDescriptor('x', '[1,2]')).toBeNull();
+    expect(wrapDescriptor('x', '"str"')).toBeNull();
+    expect(wrapDescriptor('x', '')).toBeNull();
+    expect(wrapDescriptor('x', '{"a":1')).toBeNull();
+  });
+});
+
+describe('sweepStorage', () => {
+  it('re-chunks pages larger than the batch size', async () => {
+    const redis = new FakeRedis();
+    const flat: string[] = [];
+    for (let i = 0; i < 2500; i++) flat.push(`f${i}`, `v${i}`);
+    redis.scriptedPages.set(KEY, [['1', flat]]);
+
+    const { counters, batches } = await collect(redis, true, 1000);
+    expect(batches.map(b => b.fields.length)).toEqual([1000, 1000, 500]);
+    expect(counters).toEqual({ scannedFields: 2500, unparsable: 0, pages: 1 });
+    expect(batches[0].descriptors[0]).toEqual('v0');
+    expect(batches[2].fields[499]).toEqual('f2499');
+  });
+
+  it('merges small and empty pages into full batches', async () => {
+    const redis = new FakeRedis();
+    redis.scriptedPages.set(KEY, [
+      ['1', ['a', '1', 'b', '2']],
+      ['2', []],
+      ['3', ['c', '3']],
+      ['0', ['d', '4', 'e', '5']],
+    ]);
+
+    const { counters, batches } = await collect(redis, true, 3);
+    expect(batches.map(b => b.fields)).toEqual([
+      ['a', 'b', 'c'],
+      ['d', 'e'],
+    ]);
+    expect(counters.pages).toEqual(4);
+    expect(counters.scannedFields).toEqual(5);
+  });
+
+  it('wraps values for fieldInValue: false and counts unparsable ones', async () => {
+    const redis = new FakeRedis();
+    await redis.hset(KEY, [
+      '0',
+      '{"a":"0xp"}',
+      '1',
+      'garbage',
+      '2',
+      '{"a":"0xq"}',
+    ]);
+
+    const { counters, batches } = await collect(redis, false, 10);
+    expect(batches).toHaveLength(1);
+    expect(batches[0].fields).toEqual(['0', '2']);
+    expect(batches[0].descriptors.map(d => JSON.parse(d))).toEqual([
+      { i: '0', a: '0xp' },
+      { i: '2', a: '0xq' },
+    ]);
+    expect(counters).toEqual({ scannedFields: 3, unparsable: 1, pages: 1 });
+  });
+
+  it('passes duplicate fields through untouched', async () => {
+    const redis = new FakeRedis();
+    redis.scriptedPages.set(KEY, [
+      ['1', ['a', '1', 'a', '1']],
+      ['0', ['a', '1']],
+    ]);
+    const { batches } = await collect(redis, true, 10);
+    expect(batches[0].fields).toEqual(['a', 'a', 'a']);
+  });
+
+  it('yields nothing for an empty storage', async () => {
+    const { batches, counters } = await collect(new FakeRedis(), true, 10);
+    expect(batches).toEqual([]);
+    expect(counters.pages).toEqual(1);
+  });
+});

--- a/scripts/pool-reserves-server/consumer/sweep.ts
+++ b/scripts/pool-reserves-server/consumer/sweep.ts
@@ -1,0 +1,58 @@
+import { Batch, ConsumerRedis, SweepCounters } from './types';
+
+// Wraps a stored value for `fieldInValue: false` storages without parsing
+// it: `{ i: field, ...value }` per the public contract. Values that are not
+// JSON objects cannot carry the field and are reported as unparsable.
+export function wrapDescriptor(field: string, value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed[0] !== '{' || trimmed[trimmed.length - 1] !== '}') return null;
+  const head = `{"i":${JSON.stringify(field)}`;
+  return trimmed.length === 2 || /^\{\s*\}$/.test(trimmed)
+    ? `${head}}`
+    : `${head},${trimmed.slice(1)}`;
+}
+
+// Streams a storage hash as batches of at most `batchSize` descriptors.
+// HSCAN COUNT is only a hint: pages can be larger, smaller or empty, so
+// pages are re-chunked and never passed through as batches. Memory is
+// bounded by one page plus one batch. Duplicate fields (possible while the
+// hash is being rehashed) are left to the caller's reconciliation.
+export async function* sweepStorage(
+  redis: ConsumerRedis,
+  storageKey: string,
+  fieldInValue: boolean,
+  batchSize: number,
+  counters: SweepCounters,
+): AsyncGenerator<Batch, void, void> {
+  let cursor = '0';
+  let fields: string[] = [];
+  let descriptors: string[] = [];
+
+  do {
+    const [next, flat] = await redis.hscan(storageKey, cursor, batchSize);
+    cursor = next;
+    counters.pages++;
+
+    for (let i = 0; i + 1 < flat.length; i += 2) {
+      const field = flat[i];
+      const value = flat[i + 1];
+      counters.scannedFields++;
+
+      const descriptor = fieldInValue ? value : wrapDescriptor(field, value);
+      if (descriptor === null) {
+        counters.unparsable++;
+        continue;
+      }
+      fields.push(field);
+      descriptors.push(descriptor);
+
+      if (fields.length === batchSize) {
+        yield { fields, descriptors };
+        fields = [];
+        descriptors = [];
+      }
+    }
+  } while (cursor !== '0');
+
+  if (fields.length > 0) yield { fields, descriptors };
+}

--- a/scripts/pool-reserves-server/consumer/types.ts
+++ b/scripts/pool-reserves-server/consumer/types.ts
@@ -1,0 +1,103 @@
+import { PoolReserves, PoolsStorage } from '../../../src/types';
+
+// The consumer talks to Redis through this minimal surface so the module can
+// be hosted by any client (ioredis here, whatever the backend uses there).
+export interface ConsumerRedis {
+  hlen(key: string): Promise<number>;
+  // Redis reply shape: next cursor plus a flat [field, value, field, value…]
+  hscan(
+    key: string,
+    cursor: string,
+    count: number,
+  ): Promise<[string, string[]]>;
+  // flat [field, value, field, value…]
+  hset(key: string, fieldValues: string[]): Promise<void>;
+  expire(key: string, seconds: number): Promise<void>;
+  del(keys: string[]): Promise<void>;
+  // MULTI/EXEC; each entry is a raw command with its arguments. Redis does
+  // not roll back on a command error: every command runs, the first error
+  // is rethrown afterwards.
+  transaction(commands: string[][]): Promise<void>;
+  // EVAL: the only way to make "rename if the staging hash still exists"
+  // atomic with the metadata write
+  eval(script: string, keys: string[], args: string[]): Promise<unknown>;
+}
+
+// In production this is an HTTP call to dex-lib; in the harness it is
+// `PricingHelper.getPoolReserves` in-process.
+export type GetReserves = (
+  dexKey: string,
+  pools?: string[],
+) => Promise<PoolReserves[]>;
+
+export type StorageMode = 'storage' | 'enumerated';
+
+export type Batch = { fields: string[]; descriptors: string[] };
+
+export type SweepCounters = {
+  scannedFields: number;
+  unparsable: number;
+  pages: number;
+};
+
+export type StoredReserves = {
+  address: string;
+  reserves: Record<string, string>;
+  updatedAt: number;
+  blockNumber: number | null;
+};
+
+export type CollectStats = {
+  dexKey: string;
+  chainId: number;
+  mode: StorageMode;
+  storageKey: string | null;
+  fieldInValue: boolean | null;
+  runId: string;
+  startedAt: number;
+  finishedAt: number;
+  durationMs: number;
+  blockNumber: number | null;
+  concurrency: number;
+  batchSize: number;
+  poolsInStorage: number | null;
+  scannedFields: number;
+  unparsable: number;
+  requested: number | null;
+  returned: number;
+  skipped: number | null;
+  duplicateFields: number;
+  duplicateRows: number;
+  unexpectedId: number;
+  invalid: number;
+  failedBatches: number;
+  batches: number;
+  persistedRows: number;
+  skippedSample: string[];
+  unexpectedIdSample: string[];
+  invalidSample: string[];
+  failedBatchErrors: string[];
+  zeroReserveRows: number;
+  unlimitedRows: number;
+  status: 'ok' | 'failed';
+  failure?: string;
+};
+
+export type CollectParams = {
+  dexKey: string;
+  chainId: number;
+  storage: PoolsStorage | null;
+  getReserves: GetReserves;
+  redis: ConsumerRedis;
+  keyPrefix?: string;
+  concurrency?: number;
+  batchSize?: number;
+  blockNumber?: number | null;
+  now?: () => number;
+  // a rejection for which the run must stop: the consumer built a request
+  // dex-lib refuses (wrong mode, batch too large). Anything else is a dex
+  // failure and only fails the batch.
+  isRequestError?: (e: unknown) => boolean;
+  // awaited; a rejection fails the run
+  onBatch?: (stats: Readonly<CollectStats>) => void | Promise<void>;
+};

--- a/scripts/pool-reserves-server/consumer/validate.test.ts
+++ b/scripts/pool-reserves-server/consumer/validate.test.ts
@@ -1,0 +1,54 @@
+import { validateRow } from './validate';
+import { UNLIMITED_RESERVES } from '../../../src/constants';
+
+const A = '0x' + 'a'.repeat(40);
+const B = '0x' + 'b'.repeat(40);
+const base = { dex: 'd', id: '1', address: A };
+
+describe('validateRow', () => {
+  it('accepts plain and directional rows', () => {
+    expect(
+      validateRow({ ...base, reserves: { [A]: '1', [B]: '0' } }, 'd'),
+    ).toBeNull();
+    expect(
+      validateRow(
+        { ...base, reserves: { [`${A}_${B}`]: UNLIMITED_RESERVES } },
+        'd',
+      ),
+    ).toBeNull();
+  });
+
+  it('rejects contract violations', () => {
+    expect(
+      validateRow({ ...base, reserves: { [A]: '1', [B]: '2' } }, 'other'),
+    ).toMatch(/dex/);
+    expect(
+      validateRow(
+        { ...base, address: A.toUpperCase(), reserves: { [A]: '1', [B]: '2' } },
+        'd',
+      ),
+    ).toMatch(/address/);
+    expect(validateRow({ ...base, reserves: {} }, 'd')).toMatch(/no reserves/);
+    expect(validateRow({ ...base, reserves: { [A]: '1' } }, 'd')).toMatch(
+      /single plain/,
+    );
+    expect(
+      validateRow({ ...base, reserves: { [A]: '1', [`${A}_${B}`]: '2' } }, 'd'),
+    ).toMatch(/mixed/);
+    expect(
+      validateRow({ ...base, reserves: { [A]: '01', [B]: '2' } }, 'd'),
+    ).toMatch(/value/);
+    expect(
+      validateRow({ ...base, reserves: { [A]: '-1', [B]: '2' } }, 'd'),
+    ).toMatch(/value/);
+    expect(
+      validateRow({ ...base, reserves: { [`${A}_${A}`]: '1' } }, 'd'),
+    ).toMatch(/src == dest/);
+    expect(
+      validateRow({ ...base, reserves: { [`${A}_x`]: '1' } }, 'd'),
+    ).toMatch(/key/);
+    expect(
+      validateRow({ ...base, id: '', reserves: { [A]: '1', [B]: '2' } }, 'd'),
+    ).toMatch(/id/);
+  });
+});

--- a/scripts/pool-reserves-server/consumer/validate.ts
+++ b/scripts/pool-reserves-server/consumer/validate.ts
@@ -1,0 +1,60 @@
+import { PoolReserves } from '../../../src/types';
+import { UNLIMITED_RESERVES } from '../../../src/constants';
+
+const ADDRESS_RE = /^0x[0-9a-f]{40}$/;
+const DECIMAL_RE = /^(0|[1-9][0-9]*)$/;
+
+// Structural contract of a `PoolReserves` row (same invariants as
+// tests/utils-pool-reserves.ts). Accepts anything the dex returned and
+// reports the first violation, or null when the row is well formed.
+export function validateRow(candidate: unknown, dexKey: string): string | null {
+  if (candidate === null || typeof candidate !== 'object') {
+    return `row is ${candidate === null ? 'null' : typeof candidate}`;
+  }
+  const row = candidate as Partial<PoolReserves>;
+  if (row.dex !== dexKey) return `dex ${String(row.dex)} != ${dexKey}`;
+  if (typeof row.id !== 'string' || row.id.length === 0) return 'empty id';
+  if (typeof row.address !== 'string' || !ADDRESS_RE.test(row.address)) {
+    return `address ${String(row.address)}`;
+  }
+  if (row.reserves === null || typeof row.reserves !== 'object') {
+    return 'reserves not an object';
+  }
+
+  const keys = Object.keys(row.reserves);
+  if (keys.length === 0) return 'no reserves';
+
+  let directional = 0;
+  for (const key of keys) {
+    const parts = key.split('_');
+    if (parts.length === 2) {
+      directional++;
+      if (!ADDRESS_RE.test(parts[0]) || !ADDRESS_RE.test(parts[1])) {
+        return `key ${key}`;
+      }
+      if (parts[0] === parts[1]) return `key ${key} src == dest`;
+    } else if (parts.length !== 1 || !ADDRESS_RE.test(key)) {
+      return `key ${key}`;
+    }
+
+    const value = row.reserves[key];
+    if (
+      typeof value !== 'string' ||
+      (value !== UNLIMITED_RESERVES && !DECIMAL_RE.test(value))
+    ) {
+      return `value ${key}=${String(value)}`;
+    }
+  }
+
+  if (directional !== 0 && directional !== keys.length) return 'mixed keys';
+  if (directional === 0 && keys.length < 2) return 'single plain token';
+  return null;
+}
+
+export function isZeroReserves(reserves: Record<string, string>): boolean {
+  return Object.values(reserves).every(v => v === '0');
+}
+
+export function hasUnlimited(reserves: Record<string, string>): boolean {
+  return Object.values(reserves).some(v => v === UNLIMITED_RESERVES);
+}

--- a/scripts/pool-reserves-server/pool-reserves-server.postman_collection.json
+++ b/scripts/pool-reserves-server/pool-reserves-server.postman_collection.json
@@ -1,0 +1,1082 @@
+{
+  "info": {
+    "name": "Pool reserves consumer simulation",
+    "_postman_id": "9c1d4f2e-7b31-4c0a-9a1e-3f6d2a8b5c71",
+    "description": "Local harness for the dex-lib pool-reserves API running over a copy of the production Redis. Start it with `POOL_RESERVES_CHAINS=1,8453 pnpm pool-reserves-server` (see scripts/pool-reserves-server/README.md). Collection variables: `baseUrl`, `chainId`, `dexKey`, `poolId`, `sample`. Requests carry tests for the invariants worth checking; run a folder with the Collection Runner to execute them in order.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "variable": [
+    {
+      "key": "baseUrl",
+      "value": "http://127.0.0.1:3400"
+    },
+    {
+      "key": "chainId",
+      "value": "1"
+    },
+    {
+      "key": "dexKey",
+      "value": "UniswapV2"
+    },
+    {
+      "key": "poolId",
+      "value": ""
+    },
+    {
+      "key": "sample",
+      "value": "50"
+    }
+  ],
+  "event": [
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// collection-wide: every request answers JSON",
+          "pm.test('response is JSON', () => pm.response.to.be.json);"
+        ]
+      }
+    }
+  ],
+  "item": [
+    {
+      "name": "0. Requests (no tests)",
+      "description": "Plain requests for manual use. Path variables (:dexKey, :chainId, :id) are editable in the Params tab and default to the collection variables.",
+      "item": [
+        {
+          "name": "GET health",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/health",
+              "host": ["{{baseUrl}}"],
+              "path": ["health"]
+            }
+          }
+        },
+        {
+          "name": "GET dexs on chain",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/dexs/:chainId",
+              "host": ["{{baseUrl}}"],
+              "path": ["dexs", ":chainId"],
+              "variable": [
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                }
+              ]
+            },
+            "description": "Every dex exposing getPoolReserves: mode, storage key, init outcome, storage size before init and now."
+          }
+        },
+        {
+          "name": "GET status of chain",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/status/:chainId",
+              "host": ["{{baseUrl}}"],
+              "path": ["status", ":chainId"],
+              "variable": [
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                }
+              ]
+            },
+            "description": "Init outcomes, running dex, last run, all stored reports."
+          }
+        },
+        {
+          "name": "GET pools page",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/pools/:dexKey/:chainId?cursor=0&count=20",
+              "host": ["{{baseUrl}}"],
+              "path": ["pools", ":dexKey", ":chainId"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "20"
+                }
+              ],
+              "variable": [
+                {
+                  "key": "dexKey",
+                  "value": "{{dexKey}}"
+                },
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                }
+              ]
+            },
+            "description": "HSCAN page of the storage (mode A) or last-run ids (mode B). Follow `cursor` until '0'."
+          }
+        },
+        {
+          "name": "GET one pool descriptor",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/pools/:dexKey/:chainId/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["pools", ":dexKey", ":chainId", ":id"],
+              "variable": [
+                {
+                  "key": "dexKey",
+                  "value": "{{dexKey}}"
+                },
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                },
+                {
+                  "key": "id",
+                  "value": "{{poolId}}"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "POST generate one dex",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{baseUrl}}/generate/:chainId/:dexKey",
+              "host": ["{{baseUrl}}"],
+              "path": ["generate", ":chainId", ":dexKey"],
+              "variable": [
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                },
+                {
+                  "key": "dexKey",
+                  "value": "{{dexKey}}"
+                }
+              ]
+            },
+            "description": "Sweep + getPoolReserves + publish for one dex."
+          }
+        },
+        {
+          "name": "POST generate whole chain",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{baseUrl}}/generate/:chainId",
+              "host": ["{{baseUrl}}"],
+              "path": ["generate", ":chainId"],
+              "variable": [
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                }
+              ]
+            },
+            "description": "All dexes on the chain sequentially (Mainnet ~45 s, Base ~55 s)."
+          }
+        },
+        {
+          "name": "GET reserves page",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/reserves/:dexKey/:chainId?cursor=0&count=20",
+              "host": ["{{baseUrl}}"],
+              "path": ["reserves", ":dexKey", ":chainId"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "20"
+                }
+              ],
+              "variable": [
+                {
+                  "key": "dexKey",
+                  "value": "{{dexKey}}"
+                },
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                }
+              ]
+            },
+            "description": "Published rows with `meta` (consumer report) and `harness` (RPC counters, warnings)."
+          }
+        },
+        {
+          "name": "GET one reserves row",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/reserves/:dexKey/:chainId/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["reserves", ":dexKey", ":chainId", ":id"],
+              "variable": [
+                {
+                  "key": "dexKey",
+                  "value": "{{dexKey}}"
+                },
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                },
+                {
+                  "key": "id",
+                  "value": "{{poolId}}"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "GET verify sample",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/verify/:dexKey/:chainId?sample={{sample}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["verify", ":dexKey", ":chainId"],
+              "query": [
+                {
+                  "key": "sample",
+                  "value": "{{sample}}"
+                }
+              ],
+              "variable": [
+                {
+                  "key": "dexKey",
+                  "value": "{{dexKey}}"
+                },
+                {
+                  "key": "chainId",
+                  "value": "{{chainId}}"
+                }
+              ]
+            },
+            "description": "On-chain check of sampled rows; run right after generate."
+          }
+        }
+      ]
+    },
+    {
+      "name": "0b. Examples",
+      "description": "Concrete requests with fixed dex keys.",
+      "item": [
+        {
+          "name": "Mainnet: dexs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/dexs/1",
+              "host": ["{{baseUrl}}"],
+              "path": ["dexs", "1"]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: UniswapV2 pools page",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/pools/UniswapV2/1?cursor=0&count=5",
+              "host": ["{{baseUrl}}"],
+              "path": ["pools", "UniswapV2", "1"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: PancakeSwapV2 pools page (fieldInValue: false)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/pools/PancakeSwapV2/1?cursor=0&count=5",
+              "host": ["{{baseUrl}}"],
+              "path": ["pools", "PancakeSwapV2", "1"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: generate PancakeSwapV2 (~2 s)",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{baseUrl}}/generate/1/PancakeSwapV2",
+              "host": ["{{baseUrl}}"],
+              "path": ["generate", "1", "PancakeSwapV2"]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: generate UniswapV2 (~15 s)",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{baseUrl}}/generate/1/UniswapV2",
+              "host": ["{{baseUrl}}"],
+              "path": ["generate", "1", "UniswapV2"]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: generate all (~45 s)",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{baseUrl}}/generate/1",
+              "host": ["{{baseUrl}}"],
+              "path": ["generate", "1"]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: UniswapV2 reserves",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/reserves/UniswapV2/1?cursor=0&count=5",
+              "host": ["{{baseUrl}}"],
+              "path": ["reserves", "UniswapV2", "1"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: LitePsm reserves (directional keys)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/reserves/LitePsm/1",
+              "host": ["{{baseUrl}}"],
+              "path": ["reserves", "LitePsm", "1"]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: AaveGsm reserves (seized → 0 rows)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/reserves/AaveGsm/1",
+              "host": ["{{baseUrl}}"],
+              "path": ["reserves", "AaveGsm", "1"]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: EkuboV3 reserves",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/reserves/EkuboV3/1?cursor=0&count=5",
+              "host": ["{{baseUrl}}"],
+              "path": ["reserves", "EkuboV3", "1"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: verify UniswapV2",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/verify/UniswapV2/1?sample=50",
+              "host": ["{{baseUrl}}"],
+              "path": ["verify", "UniswapV2", "1"],
+              "query": [
+                {
+                  "key": "sample",
+                  "value": "50"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: verify MaverickV2",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/verify/MaverickV2/1?sample=68",
+              "host": ["{{baseUrl}}"],
+              "path": ["verify", "MaverickV2", "1"],
+              "query": [
+                {
+                  "key": "sample",
+                  "value": "68"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Mainnet: verify EkuboV3 (id set)",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/verify/EkuboV3/1",
+              "host": ["{{baseUrl}}"],
+              "path": ["verify", "EkuboV3", "1"]
+            }
+          }
+        },
+        {
+          "name": "Base: dexs",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/dexs/8453",
+              "host": ["{{baseUrl}}"],
+              "path": ["dexs", "8453"]
+            }
+          }
+        },
+        {
+          "name": "Base: Aerodrome pools page",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/pools/Aerodrome/8453?cursor=0&count=5",
+              "host": ["{{baseUrl}}"],
+              "path": ["pools", "Aerodrome", "8453"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Base: generate all (~55 s)",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "{{baseUrl}}/generate/8453",
+              "host": ["{{baseUrl}}"],
+              "path": ["generate", "8453"]
+            }
+          }
+        },
+        {
+          "name": "Base: Aerodrome reserves",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/reserves/Aerodrome/8453?cursor=0&count=5",
+              "host": ["{{baseUrl}}"],
+              "path": ["reserves", "Aerodrome", "8453"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "5"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Base: verify Aerodrome",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/verify/Aerodrome/8453?sample=50",
+              "host": ["{{baseUrl}}"],
+              "path": ["verify", "Aerodrome", "8453"],
+              "query": [
+                {
+                  "key": "sample",
+                  "value": "50"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Base: verify QuickSwapV4",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/verify/QuickSwapV4/8453?sample=50",
+              "host": ["{{baseUrl}}"],
+              "path": ["verify", "QuickSwapV4", "8453"],
+              "query": [
+                {
+                  "key": "sample",
+                  "value": "50"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "1. Discovery",
+      "item": [
+        {
+          "name": "Health",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/health"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.test('every chain ready', () => pm.expect(body.chains.every(c => c.ready)).to.be.true);",
+                  "pm.test('no run in progress', () => pm.expect(body.chains.every(c => c.running === null)).to.be.true);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Dexes on chain",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/dexs/{{chainId}}",
+            "description": "Every dex exposing getPoolReserves on the chain: mode (storage / enumerated), storage key and fieldInValue, init outcome, storage size before dex-lib initialization (production input) and now (includes what PoolsWriter dexes published locally)."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.test('has dexes', () => pm.expect(body.count).to.be.above(0));",
+                  "pm.test('no failed or timed out init', () => {",
+                  "  const bad = body.dexs.filter(d => d.init && ['failed', 'timeout'].includes(d.init.status));",
+                  "  pm.expect(bad.map(d => d.dexKey), 'failed inits').to.eql([]);",
+                  "});",
+                  "pm.test('storage dexes point at dl_<chain>_ hashes', () => {",
+                  "  body.dexs.filter(d => d.mode === 'storage').forEach(d => pm.expect(d.storage.key).to.match(new RegExp('^dl_' + pm.collectionVariables.get('chainId') + '_')));",
+                  "});",
+                  "console.log(body.dexs.map(d => ({ dexKey: d.dexKey, mode: d.mode, init: d.init && d.init.status, before: d.poolsInStorageBeforeInit, now: d.poolsInStorageNow })));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Status of chain",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/status/{{chainId}}",
+            "description": "Init outcomes with RPC counters and captured warnings, the running dex, the last run and every stored report."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.test('chain ready', () => pm.expect(body.ready).to.be.true);"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "2. Pools (input descriptors)",
+      "item": [
+        {
+          "name": "Pools page",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/pools/{{dexKey}}/{{chainId}}?cursor=0&count=5",
+              "host": ["{{baseUrl}}"],
+              "path": ["pools", "{{dexKey}}", "{{chainId}}"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "5"
+                }
+              ]
+            },
+            "description": "One HSCAN page of the dex's storage (mode A) or of the last run's ids (mode B). `total` is HLEN; follow `cursor` until it is '0'. Sets `poolId` to the first id for the next request."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.test('mode is storage or enumerated', () => pm.expect(['storage', 'enumerated']).to.include(body.mode));",
+                  "if (body.mode === 'storage') {",
+                  "  pm.test('storage has fields', () => pm.expect(body.total).to.be.above(0));",
+                  "  if (body.pools.length) pm.collectionVariables.set('poolId', body.pools[0].id);",
+                  "} else if (body.ids && body.ids.length) {",
+                  "  pm.collectionVariables.set('poolId', body.ids[0]);",
+                  "}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "One descriptor",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/pools/{{dexKey}}/{{chainId}}/{{poolId}}",
+            "description": "HGET of one stored descriptor. Use it to classify entries from `skippedSample`: UniswapV2-family placeholders have no `exchange`."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.test('id echoed', () => pm.expect(body.id).to.eql(pm.collectionVariables.get('poolId')));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "3. Generate",
+      "item": [
+        {
+          "name": "Generate one dex",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/generate/{{chainId}}/{{dexKey}}",
+            "description": "Runs the consumer for one dex: HSCAN → batches ≤ 1000 → getPoolReserves → validate → publish. UniswapV2 on Mainnet (~450k fields) takes ~15 s."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const r = pm.response.json().reports[0];",
+                  "pm.test('run ok', () => pm.expect(r.status).to.eql('ok'));",
+                  "pm.test('no failed batches / invalid / unexpected rows', () => {",
+                  "  pm.expect(r.failedBatches, 'failedBatches').to.eql(0);",
+                  "  pm.expect(r.invalid, 'invalid').to.eql(0);",
+                  "  pm.expect(r.unexpectedId, 'unexpectedId').to.eql(0);",
+                  "});",
+                  "if (r.mode === 'storage') {",
+                  "  pm.test('accounting identity: scanned = requested + unparsable', () => pm.expect(r.scannedFields).to.eql(r.requested + r.unparsable));",
+                  "  pm.test('accounting identity: requested = returned + invalid + skipped + duplicateFields', () => pm.expect(r.requested).to.eql(r.returned + r.invalid + r.skipped + r.duplicateFields));",
+                  "  pm.test('batches never exceed 1000', () => pm.expect(r.batchSize).to.be.at.most(1000));",
+                  "}",
+                  "console.log(`${r.dexKey}: returned=${r.returned} skipped=${r.skipped} rpc=${r.rpc.jsonRpcRequests} ${r.durationMs}ms warnings=${r.samples.warnings}`);"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Generate whole chain",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/generate/{{chainId}}",
+            "description": "Every dex on the chain, sequentially. Mainnet ~45 s, Base ~55 s. Returns one report per dex."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.test('every dex ok', () => pm.expect(body.reports.filter(r => r.status !== 'ok').map(r => r.dexKey)).to.eql([]));",
+                  "pm.test('no failed batches anywhere', () => pm.expect(body.reports.filter(r => r.failedBatches > 0).map(r => r.dexKey)).to.eql([]));",
+                  "pm.test('accounting identity holds for every storage dex', () => {",
+                  "  body.reports.filter(r => r.mode === 'storage').forEach(r => {",
+                  "    pm.expect(r.requested, r.dexKey).to.eql(r.returned + r.invalid + r.skipped + r.duplicateFields);",
+                  "  });",
+                  "});",
+                  "console.log(body.reports.map(r => ({ dexKey: r.dexKey, mode: r.mode, status: r.status, before: r.poolsInStorageBeforeInit, scanned: r.scannedFields, returned: r.returned, skipped: r.skipped, rpc: r.rpc.jsonRpcRequests, ms: r.durationMs, warnings: r.samples.warnings })));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Generate while running → 409",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/generate/{{chainId}}/Weth",
+            "description": "Send while 'Generate whole chain' is still in flight in another tab to see the per-chain lock. Outside a run it returns 200."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 idle or 409 while a run is active', () => pm.expect([200, 409]).to.include(pm.response.code));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "4. Reserves (published output)",
+      "item": [
+        {
+          "name": "Reserves page",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/reserves/{{dexKey}}/{{chainId}}?cursor=0&count=5",
+              "host": ["{{baseUrl}}"],
+              "path": ["reserves", "{{dexKey}}", "{{chainId}}"],
+              "query": [
+                {
+                  "key": "cursor",
+                  "value": "0"
+                },
+                {
+                  "key": "count",
+                  "value": "5"
+                }
+              ]
+            },
+            "description": "Last published run: `meta` (consumer report), `harness` (RPC counters, captured dex-lib warnings), `lastFailure`, `total` rows and one page of rows from dexlib:pools_reserves_legacy:{<dexKey>:<chainId>}. 404 when no run was ever published."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 (404 means: run Generate first)', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.test('meta belongs to an ok run', () => pm.expect(body.meta.status).to.eql('ok'));",
+                  "pm.test('total matches persistedRows', () => pm.expect(body.total).to.eql(body.meta.persistedRows));",
+                  "pm.test('rows are well formed', () => {",
+                  "  body.reserves.forEach(row => {",
+                  "    pm.expect(row.address).to.match(/^0x[0-9a-f]{40}$/);",
+                  "    Object.entries(row.reserves).forEach(([k, v]) => {",
+                  "      pm.expect(k).to.match(/^0x[0-9a-f]{40}(_0x[0-9a-f]{40})?$/);",
+                  "      pm.expect(v).to.match(/^(0|[1-9][0-9]*|unlimited)$/);",
+                  "    });",
+                  "  });",
+                  "});",
+                  "if (body.reserves.length) pm.collectionVariables.set('poolId', body.reserves[0].id);",
+                  "console.log('skipped sample:', (body.meta.skippedSample || []).slice(0, 5));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "One reserves row",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/reserves/{{dexKey}}/{{chainId}}/{{poolId}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "pm.test('has reserves', () => pm.expect(Object.keys(pm.response.json().reserves).length).to.be.above(0));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Mode B example: LitePsm (Mainnet)",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/reserves/LitePsm/1",
+            "description": "Directional keys: gem→dai, dai→gem, gem→usds, usds→gem. No dai↔usds key."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "pm.test('one row with four directional keys', () => {",
+                  "  pm.expect(body.total).to.eql(1);",
+                  "  const keys = Object.keys(body.reserves[0].reserves);",
+                  "  pm.expect(keys.length).to.eql(4);",
+                  "  keys.forEach(k => pm.expect(k).to.include('_'));",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Mode B example: AaveGsm (Mainnet, seized → empty)",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/reserves/AaveGsm/1",
+            "description": "Both Mainnet GSMs report getIsSeized() == true on-chain, so the specified result is zero rows with a published meta (not a 404)."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 with meta and zero rows', () => {",
+                  "  pm.response.to.have.status(200);",
+                  "  const body = pm.response.json();",
+                  "  pm.expect(body.meta.status).to.eql('ok');",
+                  "  pm.expect(body.total).to.eql(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "5. Verify against chain",
+      "item": [
+        {
+          "name": "Verify sample",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/verify/{{dexKey}}/{{chainId}}?sample={{sample}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["verify", "{{dexKey}}", "{{chainId}}"],
+              "query": [
+                {
+                  "key": "sample",
+                  "value": "{{sample}}"
+                }
+              ]
+            },
+            "description": "Re-reads sampled rows on-chain: UniswapV2 family via getReserves() at the run block (then latest), token-pool dexes via balanceOf at run / state / latest block with a 1e-6 tolerance, EkuboV3 by id set. Run right after Generate: state-path dexes (MaverickV2) drift within seconds."
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const v = pm.response.json();",
+                  "const agree = v.agreeAtRunBlock + v.agreeAtStateBlock + v.agreeAtLatest + v.agreeWithinTolerance;",
+                  "pm.test('an oracle applied', () => pm.expect(v.oracle).to.not.eql('none'));",
+                  "pm.test('>= 90% of the sample agrees', () => {",
+                  "  if (v.sampled === 0) pm.expect.fail('nothing sampled: ' + v.reason);",
+                  "  pm.expect(agree / v.sampled).to.be.at.least(0.9);",
+                  "});",
+                  "console.log(`${v.dexKey}: oracle=${v.oracle} sampled=${v.sampled} agree=${agree} disagree=${v.disagree} unverified=${v.unverified}`);",
+                  "(v.checks || []).filter(c => c.result === 'disagree').slice(0, 5).forEach(c => console.log('disagree', c.id, JSON.stringify(c.detail)));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Verify EkuboV3 id set (Mainnet)",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/verify/EkuboV3/1"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200', () => pm.response.to.have.status(200));",
+                  "const v = pm.response.json();",
+                  "pm.test('published ids == pool manager pools', () => {",
+                  "  pm.expect(v.oracle).to.eql('idSet');",
+                  "  pm.expect(v.disagree).to.eql(0);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Invalid sample → 400",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "{{baseUrl}}/verify/{{dexKey}}/{{chainId}}?sample=-5",
+              "host": ["{{baseUrl}}"],
+              "path": ["verify", "{{dexKey}}", "{{chainId}}"],
+              "query": [
+                {
+                  "key": "sample",
+                  "value": "-5"
+                }
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('400', () => pm.response.to.have.status(400));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "6. Error handling",
+      "item": [
+        {
+          "name": "Unknown chain → 404",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/dexs/999999"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('404', () => pm.response.to.have.status(404));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Unknown dex → 404 with known keys",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/pools/NoSuchDex/{{chainId}}"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('404 lists known dex keys', () => {",
+                  "  pm.response.to.have.status(404);",
+                  "  pm.expect(pm.response.json().known).to.be.an('array').that.is.not.empty;",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Unknown pool id → 404",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/pools/{{dexKey}}/{{chainId}}/does-not-exist"
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('404', () => pm.response.to.have.status(404));"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/scripts/pool-reserves-server/redis-local.sh
+++ b/scripts/pool-reserves-server/redis-local.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Loads a filtered slice of a production RDB dump into a fresh local Redis.
+#
+#   scripts/pool-reserves-server/redis-local.sh <dump.rdb> [chains=1,8453] [port=6399]
+#
+# Steps: survey key names → filter to the given chains → start redis-server
+# on <port> with persistence off → pipe the filtered RESP stream in.
+# Requires redis-rdb-cli (https://github.com/leonchen83/redis-rdb-cli),
+# tested with v0.9.x on an RDB v10 (Redis 7.1) dump; RCT points at its `rct`.
+set -euo pipefail
+
+DUMP=${1:?path to dump.rdb}
+CHAINS=${2:-1,8453}
+PORT=${3:-6399}
+RCT=${RCT:-$HOME/work/paraswap/rdb-tools/redis-rdb-cli/bin/rct}
+WORK=${WORK:-$(dirname "$DUMP")/redis-local}
+mkdir -p "$WORK"
+
+ALT=$(echo "$CHAINS" | tr ',' '|')
+# composed keys `<network>_<dexKey>_<cacheKey>` (RFQ blacklists excluded:
+# 1.2M keys of no use here), dex-lib hashes `dl_<network>_…`, master keys
+# `is_…`, backend `dexlib:<kind>:<network>:…`
+REGEX="^(dl_($ALT)_.*|is_.*|($ALT)_(?!ParaSwapPool).*|dexlib:[a-z_]+:($ALT):.*)$"
+
+if [ ! -s "$WORK/filtered.resp" ]; then
+  echo "filtering keys matching $REGEX"
+  "$RCT" -f resp -s "$DUMP" -o "$WORK/filtered.resp" -k "$REGEX"
+fi
+ls -la "$WORK/filtered.resp"
+
+if ! redis-cli -p "$PORT" ping >/dev/null 2>&1; then
+  echo "starting redis-server on port $PORT"
+  redis-server --port "$PORT" --save "" --appendonly no --dir "$WORK" \
+    --daemonize yes --pidfile "$WORK/redis.pid" --logfile "$WORK/redis.log"
+  sleep 1
+fi
+
+echo "loading"
+redis-cli -p "$PORT" --pipe < "$WORK/filtered.resp"
+redis-cli -p "$PORT" dbsize
+redis-cli -p "$PORT" info memory | grep -E 'used_memory_human|used_memory_rss_human'
+for c in $(echo "$CHAINS" | tr ',' ' '); do
+  for k in $(redis-cli -p "$PORT" --scan --pattern "dl_${c}_*_pairs") \
+           $(redis-cli -p "$PORT" --scan --pattern "dl_${c}_*_pools"); do
+    printf '%-45s %s\n' "$k" "$(redis-cli -p "$PORT" hlen "$k")"
+  done
+  printf 'is_%s_bn = %s\n' "$c" "$(redis-cli -p "$PORT" get "is_${c}_bn")"
+done

--- a/scripts/pool-reserves-server/server/chain-context.ts
+++ b/scripts/pool-reserves-server/server/chain-context.ts
@@ -1,0 +1,319 @@
+import Redis from 'ioredis';
+import { Logger } from 'log4js';
+import { LocalParaswapSDK } from '../../../src/implementations/local-paraswap-sdk';
+import { PoolsStorage } from '../../../src/types';
+import { PoolReservesRequestError } from '../../../src/lib/pools-storage/reserves';
+import {
+  CollectStats,
+  StorageMode,
+  collectReserves,
+  reservesKeys,
+} from '../consumer';
+import { RedisCache, toConsumerRedis } from './redis-cache';
+import { LogCapture, RpcCounters, RpcMeter } from './instrumentation';
+
+export type DexInit = {
+  // unready: initializePricing returned but the dex holds no pools/state
+  status: 'ok' | 'unready' | 'failed' | 'timeout' | 'none';
+  durationMs: number;
+  error?: string;
+  readiness?: string;
+  rpc?: RpcCounters;
+  warnings?: string[];
+};
+
+export type DexEntry = {
+  dexKey: string;
+  mode: StorageMode;
+  storage: PoolsStorage | null;
+  poolsInStorageBeforeInit: number | null;
+  init?: DexInit;
+};
+
+// Consumer stats plus what only the harness can see.
+export type HarnessReport = CollectStats & {
+  poolsInStorageBeforeInit: number | null;
+  rpc: RpcCounters;
+  warnings: string[];
+};
+
+export type ChainRun = {
+  startedAt: number;
+  finishedAt: number | null;
+  blockNumber: number | null;
+  dexKeys: string[];
+  reports: HarnessReport[];
+};
+
+export type ChainContextOptions = {
+  masterCachePrefix: string;
+  initTimeoutMs: number;
+  concurrency: number;
+  batchSize: number;
+  keyPrefix?: string;
+};
+
+const HARNESS_SUFFIX = ':harness';
+
+const withTimeout = <T>(p: Promise<T>, ms: number, label: string) =>
+  new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`${label} timed out`)), ms);
+    p.then(resolve, reject).finally(() => clearTimeout(t));
+  });
+
+const errorMessage = (e: unknown) =>
+  e instanceof Error ? e.message : String(e);
+
+// Everything the harness holds for one chain: the slave-mode dex-lib
+// instance on top of the local Redis copy, the pool-reserve dex inventory,
+// initialization results and run history.
+export class ChainContext {
+  readonly sdk: LocalParaswapSDK;
+  readonly cache: RedisCache;
+  readonly dexes = new Map<string, DexEntry>();
+  readonly meter = new RpcMeter();
+  ready = false;
+  running: string | null = null;
+  lastRun: ChainRun | null = null;
+  readonly reports = new Map<string, HarnessReport>();
+  private readonly logger: Logger;
+
+  constructor(
+    readonly chainId: number,
+    rpcUrl: string,
+    readonly redis: Redis,
+    private readonly logCapture: LogCapture,
+    private readonly options: ChainContextOptions,
+  ) {
+    this.cache = new RedisCache(redis);
+    // dex keys are assigned after discovery: the list comes from the adapter
+    // service the SDK itself creates
+    this.sdk = new LocalParaswapSDK(chainId, [], rpcUrl, undefined, {
+      cache: this.cache,
+      isSlave: true,
+      masterCachePrefix: options.masterCachePrefix,
+    });
+    this.logger = this.sdk.dexHelper.getLogger(`PoolReservesSim-${chainId}`);
+  }
+
+  async init(): Promise<void> {
+    const storages = this.sdk.dexAdapterService.getPoolsStorages();
+    const keys: string[] = [];
+    for (const [dexKey, storage] of Object.entries(storages)) {
+      try {
+        this.sdk.dexAdapterService.getDexByKey(dexKey);
+      } catch (e) {
+        this.logger.warn(
+          `${dexKey} exposes pool reserves but is not a pricing dex: ${errorMessage(
+            e,
+          )}`,
+        );
+        continue;
+      }
+      keys.push(dexKey);
+      this.dexes.set(dexKey.toLowerCase(), {
+        dexKey,
+        mode: storage ? 'storage' : 'enumerated',
+        storage,
+        poolsInStorageBeforeInit: storage
+          ? await this.redis.hlen(storage.key)
+          : null,
+      });
+    }
+    this.sdk.dexKeys = keys;
+    this.meter.install(this.sdk.dexHelper);
+
+    const blockNumber = await this.sdk.dexHelper.provider.getBlockNumber();
+    this.logger.info(
+      `initializing ${keys.length} pool-reserve dexes at block ${blockNumber}`,
+    );
+    for (const dexKey of keys) await this.initDex(dexKey, blockNumber);
+    await this.loadStoredReports();
+    this.ready = true;
+  }
+
+  private async initDex(dexKey: string, blockNumber: number) {
+    const entry = this.dexes.get(dexKey.toLowerCase())!;
+    const dex = this.sdk.dexAdapterService.getDexByKey(dexKey);
+    const startedAt = Date.now();
+    const before = this.meter.snapshot();
+    const window = this.logCapture.open();
+    const finish = (init: Omit<DexInit, 'durationMs' | 'rpc' | 'warnings'>) => {
+      entry.init = {
+        ...init,
+        durationMs: Date.now() - startedAt,
+        rpc: RpcMeter.delta(before, this.meter.snapshot()),
+        warnings: this.logCapture.close(window),
+      };
+    };
+
+    if (!dex.initializePricing) return finish({ status: 'none' });
+    try {
+      await withTimeout(
+        Promise.resolve(dex.initializePricing(blockNumber)),
+        this.options.initTimeoutMs,
+        `${dexKey}.initializePricing`,
+      );
+      const probe = await this.readiness(dexKey);
+      finish({
+        status: probe && !probe.ready ? 'unready' : 'ok',
+        readiness: probe?.detail,
+      });
+    } catch (e) {
+      const msg = errorMessage(e);
+      finish({
+        status: msg.endsWith('timed out') ? 'timeout' : 'failed',
+        error: msg,
+      });
+    }
+  }
+
+  // Dexes that swallow their own initialization failures need a look at
+  // what they actually loaded.
+  private async readiness(
+    dexKey: string,
+  ): Promise<{ ready: boolean; detail: string } | undefined> {
+    const dex = this.sdk.dexAdapterService.getDexByKey(dexKey) as unknown as {
+      poolManager?: { poolsByString?: Map<string, unknown> };
+      pools?: Record<string, unknown> | unknown[];
+      pollingPool?: { getState?: () => Promise<unknown> };
+    };
+    const key = dexKey.toLowerCase();
+    if (key.includes('ekubo')) {
+      const n = dex.poolManager?.poolsByString?.size ?? 0;
+      return { ready: n > 0, detail: `pools=${n}` };
+    }
+    if (key.includes('maverick')) {
+      const pools = dex.pools;
+      const n = Array.isArray(pools)
+        ? pools.length
+        : Object.keys(pools ?? {}).length;
+      return { ready: n > 0, detail: `pools=${n}` };
+    }
+    if (key.includes('woofi')) {
+      // the polling object exists before its state is fetched: ask for state
+      if (!dex.pollingPool?.getState) {
+        return { ready: false, detail: 'pollingPool=missing' };
+      }
+      try {
+        const state = await withTimeout(
+          dex.pollingPool.getState(),
+          10_000,
+          `${dexKey}.getState`,
+        );
+        return {
+          ready: state !== null && state !== undefined,
+          detail: `state=${state ? 'present' : 'null'}`,
+        };
+      } catch (e) {
+        return { ready: false, detail: `state=${errorMessage(e)}` };
+      }
+    }
+    return undefined;
+  }
+
+  resolveDexKey(param: string): DexEntry | undefined {
+    return this.dexes.get(param.toLowerCase());
+  }
+
+  keys(dexKey: string) {
+    return reservesKeys(dexKey, this.chainId, this.options.keyPrefix);
+  }
+
+  async generate(dexKeys?: string[]): Promise<ChainRun> {
+    if (this.running !== null) {
+      throw new Error(
+        `run in progress on chain ${this.chainId}: ${this.running}`,
+      );
+    }
+    const targets = dexKeys ?? [...this.dexes.values()].map(d => d.dexKey);
+    const run: ChainRun = {
+      startedAt: Date.now(),
+      finishedAt: null,
+      blockNumber: null,
+      dexKeys: targets,
+      reports: [],
+    };
+    this.running = targets[0] ?? '';
+    this.lastRun = run;
+    try {
+      run.blockNumber = await this.sdk.dexHelper.provider.getBlockNumber();
+      for (const dexKey of targets) {
+        this.running = dexKey;
+        run.reports.push(await this.generateOne(dexKey, run.blockNumber));
+      }
+    } finally {
+      this.running = null;
+      run.finishedAt = Date.now();
+    }
+    return run;
+  }
+
+  private async generateOne(
+    dexKey: string,
+    blockNumber: number,
+  ): Promise<HarnessReport> {
+    const entry = this.dexes.get(dexKey.toLowerCase())!;
+    const before = this.meter.snapshot();
+    const window = this.logCapture.open();
+    let stats: CollectStats;
+    try {
+      stats = await collectReserves({
+        dexKey: entry.dexKey,
+        chainId: this.chainId,
+        storage: entry.storage,
+        getReserves: (key, pools) =>
+          this.sdk.pricingHelper.getPoolReserves(key, pools),
+        redis: toConsumerRedis(this.redis),
+        keyPrefix: this.options.keyPrefix,
+        concurrency: this.options.concurrency,
+        batchSize: this.options.batchSize,
+        blockNumber,
+        isRequestError: e => e instanceof PoolReservesRequestError,
+      });
+    } catch (e) {
+      // collectReserves only throws on invalid parameters; close the window
+      // so the next dex does not inherit it
+      this.logCapture.close(window);
+      throw e;
+    }
+    const report: HarnessReport = {
+      ...stats,
+      poolsInStorageBeforeInit: entry.poolsInStorageBeforeInit,
+      rpc: RpcMeter.delta(before, this.meter.snapshot()),
+      warnings: this.logCapture.close(window),
+    };
+    this.reports.set(entry.dexKey.toLowerCase(), report);
+    await this.redis.set(
+      this.keys(entry.dexKey).target + HARNESS_SUFFIX,
+      JSON.stringify(report),
+    );
+    this.logger.info(
+      `${entry.dexKey}: ${report.status} returned=${report.returned} skipped=${report.skipped} ` +
+        `failedBatches=${report.failedBatches} rpc=${report.rpc.jsonRpcRequests} in ${report.durationMs}ms`,
+    );
+    return report;
+  }
+
+  private async loadStoredReports() {
+    for (const entry of this.dexes.values()) {
+      const raw = await this.redis.get(
+        this.keys(entry.dexKey).target + HARNESS_SUFFIX,
+      );
+      if (raw) this.reports.set(entry.dexKey.toLowerCase(), JSON.parse(raw));
+    }
+  }
+
+  async release(timeoutMs: number): Promise<void> {
+    try {
+      await withTimeout(
+        this.sdk.releaseResources(),
+        timeoutMs,
+        'releaseResources',
+      );
+    } catch (e) {
+      this.logger.warn(`release: ${errorMessage(e)}`);
+    }
+    await this.cache.quit();
+  }
+}

--- a/scripts/pool-reserves-server/server/index.ts
+++ b/scripts/pool-reserves-server/server/index.ts
@@ -1,0 +1,393 @@
+/* eslint-disable no-console */
+import dotenv from 'dotenv';
+dotenv.config();
+
+import express, { Request, Response, NextFunction } from 'express';
+import Redis from 'ioredis';
+import { MAX_POOL_RESERVES_BATCH } from '../../../src/constants';
+import { PoolReservesRequestError } from '../../../src/lib/pools-storage/reserves';
+import { ChainContext } from './chain-context';
+import { LogCapture } from './instrumentation';
+import { verifyDex } from './verify';
+
+const env = (name: string, fallback: string) => process.env[name] ?? fallback;
+
+const config = {
+  redisUrl: env('POOL_RESERVES_REDIS_URL', 'redis://127.0.0.1:6399'),
+  port: Number(env('POOL_RESERVES_PORT', '3400')),
+  chains: env('POOL_RESERVES_CHAINS', '1,8453').split(',').map(Number),
+  masterCachePrefix: env('POOL_RESERVES_MASTER_PREFIX', 'is'),
+  concurrency: Number(env('POOL_RESERVES_CONCURRENCY', '3')),
+  batchSize: Number(
+    env('POOL_RESERVES_BATCH_SIZE', String(MAX_POOL_RESERVES_BATCH)),
+  ),
+  initTimeoutMs: Number(env('POOL_RESERVES_INIT_TIMEOUT_MS', '120000')),
+  keyPrefix: process.env.POOL_RESERVES_KEY_PREFIX,
+  logLevel: env('LOG_LEVEL', 'warn'),
+  generateOnStart: process.argv.includes('--generate'),
+  exitAfter: process.argv.includes('--exit'),
+};
+
+const logCapture = new LogCapture();
+logCapture.install(config.logLevel);
+
+const redis = new Redis(config.redisUrl, {
+  lazyConnect: true,
+  maxRetriesPerRequest: 3,
+});
+const contexts = new Map<number, ChainContext>();
+
+const parseChain = (req: Request): ChainContext => {
+  const ctx = contexts.get(Number(req.params.chainId));
+  if (!ctx) throw new HttpError(404, `unknown chainId ${req.params.chainId}`);
+  if (!ctx.ready)
+    throw new HttpError(503, `chain ${ctx.chainId} still initializing`);
+  return ctx;
+};
+
+const parseDex = (ctx: ChainContext, req: Request) => {
+  const entry = ctx.resolveDexKey(req.params.dexKey);
+  if (!entry) {
+    throw new HttpError(404, `unknown dexKey ${req.params.dexKey}`, {
+      known: [...ctx.dexes.values()].map(d => d.dexKey),
+    });
+  }
+  return entry;
+};
+
+const cursorOf = (req: Request) => String(req.query.cursor ?? '0');
+const countOf = (req: Request, fallback = 100) =>
+  Math.min(Math.max(Number(req.query.count ?? fallback), 1), 5000);
+
+class HttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+    readonly extra?: object,
+  ) {
+    super(message);
+  }
+}
+
+const app = express();
+app.use(express.json());
+
+const route =
+  (fn: (req: Request, res: Response) => Promise<unknown>) =>
+  (req: Request, res: Response, next: NextFunction) =>
+    fn(req, res)
+      .then(body => res.json(body))
+      .catch(next);
+
+app.get(
+  '/health',
+  route(async () => ({
+    ok: true,
+    chains: [...contexts.values()].map(c => ({
+      chainId: c.chainId,
+      ready: c.ready,
+      running: c.running,
+    })),
+  })),
+);
+
+app.get(
+  '/dexs/:chainId',
+  route(async req => {
+    const ctx = parseChain(req);
+    const dexs = [];
+    for (const d of ctx.dexes.values()) {
+      dexs.push({
+        ...d,
+        poolsInStorageNow: d.storage
+          ? await ctx.redis.hlen(d.storage.key)
+          : null,
+        lastReport: ctx.reports.get(d.dexKey.toLowerCase())
+          ? {
+              runId: ctx.reports.get(d.dexKey.toLowerCase())!.runId,
+              status: ctx.reports.get(d.dexKey.toLowerCase())!.status,
+            }
+          : null,
+      });
+    }
+    return { chainId: ctx.chainId, count: dexs.length, dexs };
+  }),
+);
+
+app.get(
+  '/pools/:dexKey/:chainId',
+  route(async req => {
+    const ctx = parseChain(req);
+    const entry = parseDex(ctx, req);
+    if (entry.storage) {
+      const [cursor, flat] = await ctx.redis.hscan(
+        entry.storage.key,
+        cursorOf(req),
+        'COUNT',
+        countOf(req),
+      );
+      const pools = [];
+      for (let i = 0; i + 1 < flat.length; i += 2)
+        pools.push({ id: flat[i], descriptor: tryJson(flat[i + 1]) });
+      return {
+        mode: 'storage',
+        key: entry.storage.key,
+        fieldInValue: entry.storage.fieldInValue,
+        total: await ctx.redis.hlen(entry.storage.key),
+        cursor,
+        pools,
+      };
+    }
+    const target = ctx.keys(entry.dexKey).target;
+    const [cursor, ids] = await ctx.redis.hscan(
+      target,
+      cursorOf(req),
+      'COUNT',
+      countOf(req),
+      'NOVALUES',
+    );
+    return {
+      mode: 'enumerated',
+      source: 'last-run',
+      total: await ctx.redis.hlen(target),
+      cursor,
+      ids,
+    };
+  }),
+);
+
+app.get(
+  '/pools/:dexKey/:chainId/:id',
+  route(async req => {
+    const ctx = parseChain(req);
+    const entry = parseDex(ctx, req);
+    const key = entry.storage
+      ? entry.storage.key
+      : ctx.keys(entry.dexKey).target;
+    const raw = await ctx.redis.hget(key, req.params.id);
+    if (raw === null) throw new HttpError(404, `no ${req.params.id} in ${key}`);
+    return { key, id: req.params.id, value: tryJson(raw) };
+  }),
+);
+
+app.get(
+  '/reserves/:dexKey/:chainId',
+  route(async req => {
+    const ctx = parseChain(req);
+    const entry = parseDex(ctx, req);
+    const keys = ctx.keys(entry.dexKey);
+    // one MULTI so meta, rows and count come from the same published run
+    const results = await ctx.redis
+      .multi()
+      .mget(keys.meta, keys.lastFailure)
+      .hscan(keys.target, cursorOf(req), 'COUNT', countOf(req))
+      .hlen(keys.target)
+      .exec();
+    if (!results || results.some(([err]) => err)) {
+      throw new Error('redis read failed');
+    }
+    const [meta, lastFailure] = results[0][1] as (string | null)[];
+    const [cursor, flat] = results[1][1] as [string, string[]];
+    const total = results[2][1] as number;
+    if (meta === null) {
+      throw new HttpError(
+        404,
+        `no completed run for ${entry.dexKey} on ${ctx.chainId}`,
+        { lastFailure: lastFailure ? tryJson(lastFailure) : null },
+      );
+    }
+    const reserves = [];
+    for (let i = 0; i + 1 < flat.length; i += 2) {
+      reserves.push({ id: flat[i], ...(tryJson(flat[i + 1]) as object) });
+    }
+    return {
+      meta: tryJson(meta),
+      harness: ctx.reports.get(entry.dexKey.toLowerCase()) ?? null,
+      lastFailure: lastFailure ? tryJson(lastFailure) : null,
+      total,
+      cursor,
+      reserves,
+    };
+  }),
+);
+
+app.get(
+  '/reserves/:dexKey/:chainId/:id',
+  route(async req => {
+    const ctx = parseChain(req);
+    const entry = parseDex(ctx, req);
+    const raw = await ctx.redis.hget(
+      ctx.keys(entry.dexKey).target,
+      req.params.id,
+    );
+    if (raw === null)
+      throw new HttpError(404, `no reserves for ${req.params.id}`);
+    return { id: req.params.id, ...(tryJson(raw) as object) };
+  }),
+);
+
+const generate = async (req: Request) => {
+  const ctx = parseChain(req);
+  const only = req.params.dexKey ? [parseDex(ctx, req).dexKey] : undefined;
+  if (ctx.running !== null)
+    throw new HttpError(409, `run in progress: ${ctx.running}`);
+  const run = await ctx.generate(only);
+  return { chainId: ctx.chainId, ...run, reports: run.reports.map(summarize) };
+};
+app.post('/generate/:chainId', route(generate));
+app.post('/generate/:chainId/:dexKey', route(generate));
+
+app.get(
+  '/status/:chainId',
+  route(async req => {
+    const ctx = contexts.get(Number(req.params.chainId));
+    if (!ctx) throw new HttpError(404, `unknown chainId ${req.params.chainId}`);
+    return {
+      chainId: ctx.chainId,
+      ready: ctx.ready,
+      running: ctx.running,
+      init: [...ctx.dexes.values()].map(d => ({
+        dexKey: d.dexKey,
+        mode: d.mode,
+        ...d.init,
+      })),
+      lastRun: ctx.lastRun
+        ? { ...ctx.lastRun, reports: ctx.lastRun.reports.map(summarize) }
+        : null,
+      reports: [...ctx.reports.values()].map(summarize),
+    };
+  }),
+);
+
+app.get(
+  '/verify/:dexKey/:chainId',
+  route(async req => {
+    const ctx = parseChain(req);
+    const entry = parseDex(ctx, req);
+    const sample = Number(req.query.sample ?? 50);
+    // negative HRANDFIELD counts sample with replacement: reject them
+    if (!Number.isSafeInteger(sample) || sample < 1 || sample > 500) {
+      throw new HttpError(400, 'sample must be an integer within 1..500');
+    }
+    return verifyDex(ctx, entry.dexKey, sample);
+  }),
+);
+
+app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  if (err instanceof HttpError)
+    return res.status(err.status).json({ error: err.message, ...err.extra });
+  if (err instanceof PoolReservesRequestError)
+    return res.status(400).json({ error: err.message });
+  console.error(err);
+  return res
+    .status(500)
+    .json({ error: err instanceof Error ? err.message : String(err) });
+});
+
+function tryJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    return raw;
+  }
+}
+
+// Compact view of a report for run/status responses; samples stay in
+// /reserves.
+function summarize(
+  r: ChainContext['reports'] extends Map<string, infer R> ? R : never,
+) {
+  const {
+    skippedSample,
+    unexpectedIdSample,
+    invalidSample,
+    failedBatchErrors,
+    warnings,
+    ...rest
+  } = r;
+  return {
+    ...rest,
+    samples: {
+      skipped: skippedSample.length,
+      unexpectedId: unexpectedIdSample.length,
+      invalid: invalidSample.length,
+      failedBatchErrors: failedBatchErrors.length,
+      warnings: warnings.length,
+    },
+  };
+}
+
+async function main() {
+  await redis.connect();
+  const server = app.listen(config.port, () =>
+    console.log(
+      `pool-reserves-server listening on :${config.port} (redis ${config.redisUrl})`,
+    ),
+  );
+
+  let shuttingDown = false;
+  const shutdown = async (code: number) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    server.close();
+    await Promise.all([...contexts.values()].map(c => c.release(30_000)));
+    await redis.quit();
+    process.exit(code);
+  };
+  process.on('SIGINT', () => void shutdown(0));
+  process.on('SIGTERM', () => void shutdown(0));
+
+  for (const chainId of config.chains) {
+    const rpcUrl = process.env[`HTTP_PROVIDER_${chainId}`];
+    if (!rpcUrl) {
+      console.error(`HTTP_PROVIDER_${chainId} is not set, skipping chain`);
+      continue;
+    }
+    const ctx = new ChainContext(chainId, rpcUrl, redis, logCapture, config);
+    contexts.set(chainId, ctx);
+    const startedAt = Date.now();
+    await ctx.init();
+    console.log(
+      `chain ${chainId}: ${ctx.dexes.size} pool-reserve dexes initialized in ${
+        Date.now() - startedAt
+      }ms`,
+    );
+    for (const d of ctx.dexes.values()) {
+      console.log(
+        `  ${d.dexKey.padEnd(28)} ${d.mode.padEnd(
+          10,
+        )} init=${d.init?.status.padEnd(7)} ` +
+          `storage=${d.poolsInStorageBeforeInit ?? '-'} ${
+            d.init?.readiness ?? ''
+          } ${d.init?.error ?? ''}`,
+      );
+    }
+  }
+
+  if (config.generateOnStart) {
+    for (const ctx of contexts.values()) {
+      const run = await ctx.generate();
+      console.table(
+        run.reports.map(r => ({
+          dexKey: r.dexKey,
+          mode: r.mode,
+          status: r.status,
+          storage: r.poolsInStorageBeforeInit,
+          scanned: r.scannedFields,
+          returned: r.returned,
+          skipped: r.skipped,
+          failedBatches: r.failedBatches,
+          rpc: r.rpc.jsonRpcRequests,
+          ms: r.durationMs,
+          warnings: r.warnings.length,
+        })),
+      );
+    }
+    if (config.exitAfter) await shutdown(0);
+  }
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/pool-reserves-server/server/instrumentation.ts
+++ b/scripts/pool-reserves-server/server/instrumentation.ts
@@ -1,0 +1,148 @@
+import log4js from 'log4js';
+import { IDexHelper } from '../../../src/dex-helper';
+
+export type RpcCounters = {
+  jsonRpcRequests: number;
+  multicallCalls: number;
+  multicallSubCalls: number;
+};
+
+// Counts network-level JSON-RPC requests (ethers + web3 providers) and
+// MultiWrapper aggregate/tryAggregate invocations with their sub-call
+// totals. Counters are process-wide for the helper they are installed on;
+// callers take deltas around the phase they measure.
+export class RpcMeter {
+  readonly counters: RpcCounters = {
+    jsonRpcRequests: 0,
+    multicallCalls: 0,
+    multicallSubCalls: 0,
+  };
+
+  install(dexHelper: IDexHelper): void {
+    const provider = dexHelper.provider as unknown as {
+      send: (method: string, params: unknown[]) => Promise<unknown>;
+    };
+    const ethersSend = provider.send.bind(provider);
+    provider.send = (method, params) => {
+      this.counters.jsonRpcRequests++;
+      return ethersSend(method, params);
+    };
+
+    const web3Provider = dexHelper.web3Provider.currentProvider as unknown as {
+      send?: (payload: unknown, cb: unknown) => unknown;
+    } | null;
+    if (web3Provider?.send) {
+      const web3Send = web3Provider.send.bind(web3Provider);
+      web3Provider.send = (payload, cb) => {
+        this.counters.jsonRpcRequests += Array.isArray(payload)
+          ? payload.length
+          : 1;
+        return web3Send(payload, cb);
+      };
+    }
+
+    for (const wrapper of [
+      dexHelper.multiWrapper,
+      dexHelper.multiNonZeroSenderWrapper,
+    ]) {
+      const w = wrapper as unknown as Record<
+        string,
+        (...a: unknown[]) => unknown
+      >;
+      const aggregate = w.aggregate.bind(wrapper);
+      w.aggregate = (calls: unknown, ...rest: unknown[]) => {
+        this.count(calls);
+        return aggregate(calls, ...rest);
+      };
+      const tryAggregate = w.tryAggregate.bind(wrapper);
+      w.tryAggregate = (
+        mandatory: unknown,
+        calls: unknown,
+        ...rest: unknown[]
+      ) => {
+        this.count(calls);
+        return tryAggregate(mandatory, calls, ...rest);
+      };
+    }
+  }
+
+  private count(calls: unknown) {
+    this.counters.multicallCalls++;
+    if (Array.isArray(calls)) this.counters.multicallSubCalls += calls.length;
+  }
+
+  snapshot(): RpcCounters {
+    return { ...this.counters };
+  }
+
+  static delta(before: RpcCounters, after: RpcCounters): RpcCounters {
+    return {
+      jsonRpcRequests: after.jsonRpcRequests - before.jsonRpcRequests,
+      multicallCalls: after.multicallCalls - before.multicallCalls,
+      multicallSubCalls: after.multicallSubCalls - before.multicallSubCalls,
+    };
+  }
+}
+
+const MAX_CAPTURED = 200;
+
+const format = (data: unknown[]): string =>
+  data
+    .map(d => {
+      if (d instanceof Error) return d.message;
+      if (typeof d === 'string') return d;
+      try {
+        return JSON.stringify(d);
+      } catch (e) {
+        return String(d);
+      }
+    })
+    .join(' ')
+    .slice(0, 500);
+
+export type CaptureWindow = { lines: string[] };
+
+// Captures warn/error lines from every log4js category while at least one
+// window is open. dex-lib swallows RPC failures into logs, so this is the
+// only place they surface for the report. Windows are independent: an event
+// lands in every open window, so concurrent chains see an upper bound
+// rather than losing each other's lines.
+export class LogCapture {
+  private readonly windows = new Set<CaptureWindow>();
+
+  install(stdoutLevel: string): void {
+    const capture = {
+      configure: () => (event: log4js.LoggingEvent) => {
+        if (this.windows.size === 0) return;
+        if (event.level.level < log4js.levels.WARN.level) return;
+        const line = `[${event.level.levelStr}] ${event.categoryName}: ${format(
+          event.data,
+        )}`;
+        for (const w of this.windows) {
+          if (w.lines.length < MAX_CAPTURED) w.lines.push(line);
+        }
+      },
+    };
+    log4js.configure({
+      appenders: {
+        stdout: { type: 'stdout' },
+        out: { type: 'logLevelFilter', appender: 'stdout', level: stdoutLevel },
+        capture: { type: capture },
+      },
+      categories: {
+        default: { appenders: ['out', 'capture'], level: 'debug' },
+      },
+    });
+  }
+
+  open(): CaptureWindow {
+    const w: CaptureWindow = { lines: [] };
+    this.windows.add(w);
+    return w;
+  }
+
+  close(w: CaptureWindow): string[] {
+    this.windows.delete(w);
+    return w.lines;
+  }
+}

--- a/scripts/pool-reserves-server/server/redis-cache.ts
+++ b/scripts/pool-reserves-server/server/redis-cache.ts
@@ -1,0 +1,255 @@
+import Redis from 'ioredis';
+import { ICache } from '../../../src/dex-helper/icache';
+import { ConsumerRedis } from '../consumer';
+
+export type ComposeKey = (
+  dexKey: string,
+  network: number,
+  cacheKey: string,
+) => string;
+
+// The production backend composes `<network>_<dexKey>_<cacheKey>` verbatim
+// (no lowercasing); confirmed against the 2026-09-10 dump, e.g.
+// `1_ParaSwapPool14_blacklisted_0x…`.
+export const productionComposeKey: ComposeKey = (dexKey, network, cacheKey) =>
+  `${network}_${dexKey}_${cacheKey}`;
+
+// ICache over ioredis. Hash/set/zset/raw methods map 1:1; the
+// `*AndCacheLocally` variants do not cache because a verification tool
+// wants fresh reads.
+export class RedisCache implements ICache {
+  private subscriber?: Redis;
+  private readonly channelRefs = new Map<string, number>();
+
+  constructor(
+    private readonly redis: Redis,
+    private readonly composeKey: ComposeKey = productionComposeKey,
+    private readonly onError: (context: string, e: unknown) => void = (
+      context,
+      e,
+      // eslint-disable-next-line no-console
+    ) => console.error(`RedisCache: ${context} failed`, e),
+  ) {}
+
+  get(dexKey: string, network: number, cacheKey: string) {
+    return this.redis.get(this.composeKey(dexKey, network, cacheKey));
+  }
+
+  async mget(keys: string[]) {
+    return keys.length ? this.redis.mget(...keys) : [];
+  }
+
+  ttl(dexKey: string, network: number, cacheKey: string) {
+    return this.redis.ttl(this.composeKey(dexKey, network, cacheKey));
+  }
+
+  keys(dexKey: string, network: number, cacheKey: string) {
+    return this.redis.keys(this.composeKey(dexKey, network, cacheKey));
+  }
+
+  rawget(key: string) {
+    return this.redis.get(key);
+  }
+
+  rawset(key: string, value: string, ttl: number) {
+    return this.redis.set(key, value, 'EX', ttl);
+  }
+
+  async rawdel(key: string) {
+    await this.redis.del(key);
+  }
+
+  del(dexKey: string, network: number, cacheKey: string) {
+    return this.redis.del(this.composeKey(dexKey, network, cacheKey));
+  }
+
+  async setex(
+    dexKey: string,
+    network: number,
+    cacheKey: string,
+    ttlSeconds: number,
+    value: string,
+  ) {
+    await this.redis.setex(
+      this.composeKey(dexKey, network, cacheKey),
+      ttlSeconds,
+      value,
+    );
+  }
+
+  async msetex(...args: Array<string | number>) {
+    if (args.length % 3 !== 0) throw new Error('msetex: wrong arity');
+    const pipeline = this.redis.pipeline();
+    for (let i = 0; i < args.length; i += 3) {
+      pipeline.setex(String(args[i]), Number(args[i + 2]), String(args[i + 1]));
+    }
+    const results = await pipeline.exec();
+    const failed = results?.find(([err]) => err);
+    if (failed) throw failed[0];
+  }
+
+  async set(key: string, value: string) {
+    await this.redis.set(key, value);
+  }
+
+  async mset(...args: string[]) {
+    if (args.length) await this.redis.mset(...args);
+  }
+
+  getAndCacheLocally(dexKey: string, network: number, cacheKey: string) {
+    return this.get(dexKey, network, cacheKey);
+  }
+
+  mgetAndCacheLocally(keys: string[]) {
+    return this.mget(keys);
+  }
+
+  setexAndCacheLocally(
+    dexKey: string,
+    network: number,
+    cacheKey: string,
+    ttlSeconds: number,
+    value: string,
+  ) {
+    return this.setex(dexKey, network, cacheKey, ttlSeconds, value);
+  }
+
+  async sadd(setKey: string, key: string) {
+    await this.redis.sadd(setKey, key);
+  }
+
+  zadd(key: string, bulk: (number | string)[], option?: 'NX') {
+    return option
+      ? this.redis.zadd(key, option, ...bulk)
+      : this.redis.zadd(key, ...bulk);
+  }
+
+  zremrangebyscore(key: string, min: number, max: number) {
+    return this.redis.zremrangebyscore(key, min, max);
+  }
+
+  async zrem(key: string, members: string[]) {
+    return members.length ? this.redis.zrem(key, ...members) : 0;
+  }
+
+  zscore(setKey: string, key: string) {
+    return this.redis.zscore(setKey, key);
+  }
+
+  async sismember(setKey: string, key: string) {
+    return (await this.redis.sismember(setKey, key)) === 1;
+  }
+
+  smembers(setKey: string) {
+    return this.redis.smembers(setKey);
+  }
+
+  async hset(mapKey: string, key: string, value: string) {
+    await this.redis.hset(mapKey, key, value);
+  }
+
+  async hdel(mapKey: string, keys: string[]) {
+    return keys.length ? this.redis.hdel(mapKey, ...keys) : 0;
+  }
+
+  hget(mapKey: string, key: string) {
+    return this.redis.hget(mapKey, key);
+  }
+
+  hlen(mapKey: string) {
+    return this.redis.hlen(mapKey);
+  }
+
+  async hmget(mapKey: string, keys: string[]) {
+    return keys.length ? this.redis.hmget(mapKey, ...keys) : [];
+  }
+
+  async hmset(mapKey: string, mappings: Record<string, string>) {
+    if (Object.keys(mappings).length) await this.redis.hset(mapKey, mappings);
+  }
+
+  hgetAll(mapKey: string) {
+    return this.redis.hgetall(mapKey);
+  }
+
+  async hscan(mapKey: string, cursor: string, count: number) {
+    const [next, flat] = await this.redis.hscan(mapKey, cursor, 'COUNT', count);
+    const entries: Record<string, string> = {};
+    for (let i = 0; i + 1 < flat.length; i += 2) entries[flat[i]] = flat[i + 1];
+    return { cursor: next, entries };
+  }
+
+  async publish(channel: string, msg: string) {
+    await this.redis.publish(channel, msg);
+  }
+
+  subscribe(channel: string, cb: (channel: string, msg: string) => void) {
+    if (!this.subscriber) this.subscriber = this.redis.duplicate();
+    const sub = this.subscriber;
+    const handler = (ch: string, msg: string) => {
+      if (ch === channel) cb(ch, msg);
+    };
+    sub.on('message', handler);
+    const count = (this.channelRefs.get(channel) ?? 0) + 1;
+    this.channelRefs.set(channel, count);
+    if (count === 1) {
+      sub
+        .subscribe(channel)
+        .catch(e => this.onError(`subscribe ${channel}`, e));
+    }
+    return () => {
+      sub.off('message', handler);
+      const left = (this.channelRefs.get(channel) ?? 1) - 1;
+      if (left <= 0) {
+        this.channelRefs.delete(channel);
+        sub
+          .unsubscribe(channel)
+          .catch(e => this.onError(`unsubscribe ${channel}`, e));
+      } else {
+        this.channelRefs.set(channel, left);
+      }
+    };
+  }
+
+  addBatchHGet(
+    mapKey: string,
+    key: string,
+    cb: (result: string | null) => boolean,
+  ) {
+    void this.redis
+      .hget(mapKey, key)
+      .then(cb)
+      .catch(() => cb(null));
+  }
+
+  async quit() {
+    await this.subscriber?.quit();
+  }
+}
+
+export function toConsumerRedis(redis: Redis): ConsumerRedis {
+  return {
+    hlen: key => redis.hlen(key),
+    hscan: (key, cursor, count) => redis.hscan(key, cursor, 'COUNT', count),
+    hset: async (key, fieldValues) => {
+      if (fieldValues.length) await redis.hset(key, ...fieldValues);
+    },
+    expire: async (key, seconds) => {
+      await redis.expire(key, seconds);
+    },
+    del: async keys => {
+      if (keys.length) await redis.del(...keys);
+    },
+    transaction: async commands => {
+      // ioredis dispatches MULTI entries by method name, hence lowercase
+      const results = await redis
+        .multi(commands.map(([cmd, ...args]) => [cmd.toLowerCase(), ...args]))
+        .exec();
+      if (!results) throw new Error('transaction aborted');
+      const failed = results.find(([err]) => err);
+      if (failed) throw failed[0];
+    },
+    eval: (script, keys, args) =>
+      redis.eval(script, keys.length, ...keys, ...args),
+  };
+}

--- a/scripts/pool-reserves-server/server/verify.ts
+++ b/scripts/pool-reserves-server/server/verify.ts
@@ -1,0 +1,355 @@
+import { Interface } from '@ethersproject/abi';
+import { BytesLike } from '@ethersproject/bytes';
+import { MultiResult } from '../../../src/lib/multi-wrapper';
+import { generalDecoder } from '../../../src/lib/decoders';
+import { UNLIMITED_RESERVES } from '../../../src/constants';
+import { UniswapV2 } from '../../../src/dex/uniswap-v2/uniswap-v2';
+import { StoredReserves } from '../consumer';
+import { ChainContext } from './chain-context';
+
+type Oracle = 'getReserves' | 'balanceOf' | 'idSet' | 'none';
+
+export type PoolCheck = {
+  id: string;
+  address: string;
+  result:
+    | 'agreeAtStateBlock'
+    | 'agreeAtRunBlock'
+    | 'agreeAtLatest'
+    | 'agreeWithinTolerance'
+    | 'disagree'
+    | 'unverified';
+  stateBlock?: number;
+  detail?: Record<
+    string,
+    { stored: string; runBlock?: string; latest?: string }
+  >;
+  reason?: string;
+};
+
+export type VerifyReport = {
+  dexKey: string;
+  chainId: number;
+  oracle: Oracle;
+  runBlock: number | null;
+  latestBlock: number;
+  eligible: number;
+  sampled: number;
+  agreeAtStateBlock: number;
+  agreeAtRunBlock: number;
+  agreeAtLatest: number;
+  // relative difference <= TOLERANCE (state accounting vs token balance dust)
+  agreeWithinTolerance: number;
+  disagree: number;
+  unverified: number;
+  reason?: string;
+  checks: PoolCheck[];
+};
+
+// 1e-6: Maverick/Algebra reserves are state accounting; the pool's token
+// balance can carry protocol-fee dust on top.
+const TOLERANCE_PPM = 1n;
+
+const withinTolerance = (stored: string, onChain: string): boolean => {
+  const a = BigInt(stored);
+  const b = BigInt(onChain);
+  const diff = a > b ? a - b : b - a;
+  const base = a > b ? a : b;
+  return base === 0n ? diff === 0n : diff * 1_000_000n <= base * TOLERANCE_PPM;
+};
+
+const erc20 = new Interface([
+  'function balanceOf(address) view returns (uint256)',
+]);
+const pair = new Interface([
+  'function getReserves() view returns (uint112,uint112,uint32)',
+]);
+
+const strictUint = (r: MultiResult<BytesLike> | BytesLike): bigint =>
+  generalDecoder(r, ['uint256'], undefined, v => v[0].toBigInt());
+const reservesDecoder = (
+  r: MultiResult<BytesLike> | BytesLike,
+): [bigint, bigint] =>
+  generalDecoder(r, ['uint112', 'uint112', 'uint32'], undefined, v => [
+    v[0].toBigInt(),
+    v[1].toBigInt(),
+  ]);
+
+type Row = { id: string } & StoredReserves;
+
+// Best-effort: the block at which the dex's in-memory state for this pool
+// was set. State-path values (Maverick, Algebra) are exact at that block,
+// not at the run block. Looks through the usual pool maps by address.
+function stateBlockOf(dex: unknown, address: string): number | null {
+  const d = dex as Record<string, unknown>;
+  for (const field of ['pools', 'eventPools']) {
+    const pools = d[field];
+    if (!pools || typeof pools !== 'object') continue;
+    const values =
+      pools instanceof Map ? [...pools.values()] : Object.values(pools);
+    for (const pool of values as Array<Record<string, unknown>>) {
+      const addr = (pool?.poolAddress ?? pool?.address) as string | undefined;
+      if (typeof addr === 'string' && addr.toLowerCase() === address) {
+        const fn = pool.getStateBlockNumber;
+        if (typeof fn === 'function') {
+          const bn = Number((fn as () => number).call(pool));
+          return bn > 0 ? bn : null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+// Metadata, a random sample (HRANDFIELD, O(sample)) and the count of the
+// published hash in one MULTI, so a publication in between cannot pair one
+// run's metadata with another run's rows.
+async function snapshot(ctx: ChainContext, dexKey: string, sample: number) {
+  const keys = ctx.keys(dexKey);
+  const results = await ctx.redis
+    .multi()
+    .get(keys.meta)
+    .hrandfield(keys.target, sample, 'WITHVALUES')
+    .hlen(keys.target)
+    .exec();
+  if (!results || results.some(([err]) => err)) {
+    throw new Error('redis read failed');
+  }
+  const metaRaw = results[0][1] as string | null;
+  const flat = results[1][1] as string[] | null;
+  const total = results[2][1] as number;
+  const rows: Row[] = [];
+  for (let i = 0; flat && i + 1 < flat.length; i += 2) {
+    rows.push({ id: flat[i], ...(JSON.parse(flat[i + 1]) as StoredReserves) });
+  }
+  const meta = metaRaw
+    ? (JSON.parse(metaRaw) as { blockNumber?: number | null })
+    : null;
+  return { rows, total, runBlock: meta?.blockNumber ?? null };
+}
+
+const plainTokens = (row: Row): string[] | null => {
+  const keys = Object.keys(row.reserves);
+  if (keys.length < 2 || keys.some(k => k.includes('_'))) return null;
+  if (Object.values(row.reserves).includes(UNLIMITED_RESERVES)) return null;
+  return keys;
+};
+
+// Reads the same quantity the dex reported, first at the run block and, on
+// a mismatch, at the latest block (a swap in between is the benign case).
+export async function verifyDex(
+  ctx: ChainContext,
+  dexKey: string,
+  sample: number,
+): Promise<VerifyReport> {
+  const dex = ctx.sdk.dexAdapterService.getDexByKey(dexKey);
+  // the published metadata, not ctx.reports: the latest report may describe
+  // a failed run whose rows were never published
+  const { rows, total, runBlock } = await snapshot(ctx, dexKey, sample);
+  const latestBlock = await ctx.sdk.dexHelper.provider.getBlockNumber();
+  const out: VerifyReport = {
+    dexKey,
+    chainId: ctx.chainId,
+    oracle: 'none',
+    runBlock,
+    latestBlock,
+    eligible: 0,
+    sampled: 0,
+    agreeAtStateBlock: 0,
+    agreeAtRunBlock: 0,
+    agreeAtLatest: 0,
+    agreeWithinTolerance: 0,
+    disagree: 0,
+    unverified: 0,
+    checks: [],
+  };
+
+  if (dexKey.toLowerCase().includes('ekubo')) {
+    return verifyIdSet(ctx, dex, dexKey, out);
+  }
+
+  out.eligible = total;
+  const candidates = rows.filter(r => plainTokens(r) !== null);
+  if (candidates.length === 0) {
+    out.reason =
+      rows.length === 0
+        ? 'no published rows'
+        : 'rows are directional or unlimited: no on-chain balance oracle';
+    out.unverified = rows.length;
+    return out;
+  }
+  out.sampled = candidates.length;
+
+  const isUniV2 = dex instanceof UniswapV2;
+  out.oracle = isUniV2 ? 'getReserves' : 'balanceOf';
+  const read = (block: number | null, rows: Row[] = candidates) =>
+    isUniV2
+      ? readGetReserves(ctx, rows, block)
+      : readBalances(ctx, rows, block);
+
+  const atRun = runBlock !== null ? await read(runBlock) : null;
+  let atLatest: Map<string, Record<string, string | null>> | null = null;
+
+  for (const row of candidates) {
+    const tokens = plainTokens(row)!;
+    const check: PoolCheck = {
+      id: row.id,
+      address: row.address,
+      result: 'unverified',
+      detail: {},
+    };
+    const runValues = atRun?.get(row.id);
+    const agrees = (values: Record<string, string | null> | undefined) =>
+      values !== undefined &&
+      tokens.every(t => values[t] !== null && values[t] === row.reserves[t]);
+
+    const stateBlock = isUniV2 ? null : stateBlockOf(dex, row.address);
+    if (stateBlock !== null) check.stateBlock = stateBlock;
+    if (agrees(runValues)) {
+      check.result = 'agreeAtRunBlock';
+    } else if (
+      stateBlock !== null &&
+      stateBlock !== runBlock &&
+      agrees((await read(stateBlock, [row])).get(row.id))
+    ) {
+      check.result = 'agreeAtStateBlock';
+    } else {
+      if (!atLatest) atLatest = await read(null);
+      const latestValues = atLatest.get(row.id);
+      const near = (values: Record<string, string | null> | undefined) =>
+        values !== undefined &&
+        tokens.every(
+          t =>
+            values[t] !== null && withinTolerance(row.reserves[t], values[t]!),
+        );
+      if (agrees(latestValues)) check.result = 'agreeAtLatest';
+      else if (near(runValues) || near(latestValues)) {
+        check.result = 'agreeWithinTolerance';
+      } else if (
+        (runValues && tokens.some(t => runValues[t] === null)) ||
+        (latestValues && tokens.some(t => latestValues[t] === null))
+      ) {
+        check.result = 'unverified';
+        check.reason = 'oracle call failed';
+      } else check.result = 'disagree';
+      for (const t of tokens) {
+        check.detail![t] = {
+          stored: row.reserves[t],
+          runBlock: runValues?.[t] ?? undefined,
+          latest: latestValues?.[t] ?? undefined,
+        };
+      }
+    }
+    if (check.result.startsWith('agreeAt')) delete check.detail;
+    out[check.result]++;
+    out.checks.push(check);
+  }
+  return out;
+}
+
+async function readBalances(
+  ctx: ChainContext,
+  rows: Row[],
+  block: number | null,
+): Promise<Map<string, Record<string, string | null>>> {
+  const calls = rows.flatMap(row =>
+    plainTokens(row)!.map(token => ({
+      target: token,
+      callData: erc20.encodeFunctionData('balanceOf', [row.address]),
+      decodeFunction: strictUint,
+    })),
+  );
+  const results = await ctx.sdk.dexHelper.multiWrapper.tryAggregate(
+    false,
+    calls,
+    block ?? undefined,
+    200,
+    false,
+  );
+  const out = new Map<string, Record<string, string | null>>();
+  let i = 0;
+  for (const row of rows) {
+    const values: Record<string, string | null> = {};
+    for (const token of plainTokens(row)!) {
+      const r = results[i++];
+      values[token] = r.success ? r.returnData.toString() : null;
+    }
+    out.set(row.id, values);
+  }
+  return out;
+}
+
+async function readGetReserves(
+  ctx: ChainContext,
+  rows: Row[],
+  block: number | null,
+): Promise<Map<string, Record<string, string | null>>> {
+  const results = await ctx.sdk.dexHelper.multiWrapper.tryAggregate(
+    false,
+    rows.map(row => ({
+      target: row.address,
+      callData: pair.encodeFunctionData('getReserves'),
+      decodeFunction: reservesDecoder,
+    })),
+    block ?? undefined,
+    200,
+    false,
+  );
+  const out = new Map<string, Record<string, string | null>>();
+  rows.forEach((row, i) => {
+    const [t0, t1] = plainTokens(row)!.slice().sort();
+    const r = results[i];
+    out.set(
+      row.id,
+      r.success
+        ? { [t0]: r.returnData[0].toString(), [t1]: r.returnData[1].toString() }
+        : { [t0]: null, [t1]: null },
+    );
+  });
+  return out;
+}
+
+// EkuboV3 reports virtual TVL from state; the only independent check is
+// that the published ids are exactly the manager's valid pools.
+async function verifyIdSet(
+  ctx: ChainContext,
+  dex: unknown,
+  dexKey: string,
+  out: VerifyReport,
+): Promise<VerifyReport> {
+  out.oracle = 'idSet';
+  const manager = (
+    dex as {
+      poolManager?: {
+        poolsByString?: Map<string, { isInvalid?: () => boolean }>;
+      };
+    }
+  ).poolManager;
+  const expected = new Set<string>();
+  for (const [k, pool] of manager?.poolsByString ?? []) {
+    if (!pool.isInvalid?.()) expected.add(k);
+  }
+  const published = new Set(await ctx.redis.hkeys(ctx.keys(dexKey).target));
+  out.eligible = expected.size;
+  out.sampled = published.size;
+  const missing = [...expected].filter(k => !published.has(k));
+  const extra = [...published].filter(k => !expected.has(k));
+  out.agreeAtRunBlock = published.size - extra.length;
+  out.disagree = missing.length + extra.length;
+  out.reason = `missing=${missing.length} extra=${extra.length}`;
+  out.checks = [
+    ...missing.slice(0, 20).map(id => ({
+      id,
+      address: '',
+      result: 'disagree' as const,
+      reason: 'not published',
+    })),
+    ...extra.slice(0, 20).map(id => ({
+      id,
+      address: '',
+      result: 'disagree' as const,
+      reason: 'not in pool manager',
+    })),
+  ];
+  return out;
+}

--- a/scripts/pool-reserves-server/tsconfig.json
+++ b/scripts/pool-reserves-server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "noEmit": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["./**/*.ts", "../../src/**/*.ts"],
+  "exclude": ["../../src/**/*.test.ts"]
+}

--- a/src/dex-helper/dummy-dex-helper.ts
+++ b/src/dex-helper/dummy-dex-helper.ts
@@ -372,6 +372,13 @@ class DummyBlockManager implements IBlockManager {
   }
 }
 
+export type DummyDexHelperOptions = {
+  // replaces the in-memory DummyCache, e.g. with a real Redis-backed ICache
+  cache?: ICache;
+  isSlave?: boolean;
+  masterCachePrefix?: string;
+};
+
 export class DummyDexHelper implements IDexHelper {
   config: ConfigHelper;
   cache: ICache;
@@ -391,9 +398,17 @@ export class DummyDexHelper implements IDexHelper {
     tokenAmounts: [toke: string, amount: bigint | null][],
   ) => Promise<number[]>;
 
-  constructor(network: number, rpcUrl?: string) {
-    this.config = new ConfigHelper(false, generateConfig(network), 'is');
-    this.cache = new DummyCache();
+  constructor(
+    network: number,
+    rpcUrl?: string,
+    options: DummyDexHelperOptions = {},
+  ) {
+    this.config = new ConfigHelper(
+      options.isSlave ?? false,
+      generateConfig(network),
+      options.masterCachePrefix ?? 'is',
+    );
+    this.cache = options.cache ?? new DummyCache();
     this.httpRequest = new DummyRequestWrapper(this.config.data.apiKeyTheGraph);
     this.provider = new StaticJsonRpcProvider(
       rpcUrl ? rpcUrl : this.config.data.privateHttpProvider,

--- a/src/dex-helper/index.ts
+++ b/src/dex-helper/index.ts
@@ -11,6 +11,6 @@ export {
 
 export { IBlockManager, EventSubscriber } from './iblock-manager';
 
-export { DummyDexHelper } from './dummy-dex-helper';
+export { DummyDexHelper, DummyDexHelperOptions } from './dummy-dex-helper';
 
 export { DummyLimitOrderProvider } from './dummy-limit-order-provider';

--- a/src/implementations/local-paraswap-sdk.ts
+++ b/src/implementations/local-paraswap-sdk.ts
@@ -1,6 +1,7 @@
 import * as _ from 'lodash';
 import {
   DummyDexHelper,
+  DummyDexHelperOptions,
   DummyLimitOrderProvider,
   IDexHelper,
 } from '../dex-helper';
@@ -72,8 +73,9 @@ export class LocalParaswapSDK implements IParaSwapSDK {
     dexKeys: string | string[],
     rpcUrl: string,
     limitOrderProvider?: DummyLimitOrderProvider,
+    dexHelperOptions?: DummyDexHelperOptions,
   ) {
-    this.dexHelper = new DummyDexHelper(this.network, rpcUrl);
+    this.dexHelper = new DummyDexHelper(this.network, rpcUrl, dexHelperOptions);
     this.dexAdapterService = new DexAdapterService(
       this.dexHelper,
       this.network,


### PR DESCRIPTION
Linear: DEXLIB-304

## What

A local server over `LocalParaswapSDK` (`pnpm pool-reserves-server`) that exercises the pool reserves API end to end against a copy of the production Redis (`scripts/pool-reserves-server/redis-local.sh` filters an RDB dump into a local Redis):

- `/dexs/:chainId`, `/pools/:dexKey/:chainId`, `/reserves/:dexKey/:chainId`, `/verify/...` with on-chain oracles (getReserves / balanceOf at the run block).
- A portable TypeScript consumer (`scripts/pool-reserves-server/consumer/`): streaming HSCAN re-chunked to 1000, worker pool, per-batch reconciliation with the identity `requested = returned + invalid + skipped + duplicateFields`, RPC and Redis meters.
- `DummyDexHelper` options (`cache`, `isSlave`, `masterCachePrefix`) and a 5th `LocalParaswapSDK` parameter so the harness runs in slave mode on a real Redis.
- Postman collection and `docs/pool-reserves-consumer-sim-plan.md` with the production-data measurements (§8, §11).

## Why

This is the reference implementation the Go consumer in `go-route-advisor` was ported from, and the way to reproduce reserve generation locally without staging. It is not deployed anywhere; draft until the team decides whether to keep it in the repo.

Based on `feat/pool-tracker-deprecation`.